### PR TITLE
Fix mapc not to merge planes that are not perfectly coplanar

### DIFF
--- a/share/mapc.c
+++ b/share/mapc.c
@@ -1797,8 +1797,8 @@ static int comp_edge(const struct b_edge *ep, const struct b_edge *eq)
 
 static int comp_side(const struct b_side *sp, const struct b_side *sq)
 {
-    if (fabsf(sp->d - sq->d) > SMALL)  return 0;
-    if (v_dot(sp->n,  sq->n) < 0.9999) return 0;
+    if (fabsf(sp->d - sq->d) > SMALL) return 0;
+    if (v_dot(sp->n,  sq->n) < 1.0f)  return 0;
 
     return 1;
 }


### PR DESCRIPTION
This fixes a problem that was discovered in map-mym2/littlecones.map a
really, really long time ago, where mapc seemingly had merged together
planes from two cones that were nearly-but-not-quite coplanar. This
caused a nasty collision artifact at the top of the cone in front of
the spawn point.

The downside of this patch is an about 10% increase in total SOL size.
