### PR TITLE
Mapc output to Radiant console over TCP

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -87,6 +87,10 @@ ifeq ($(ENABLE_HMD),libovr)
 	ALL_CPPFLAGS += -DENABLE_HMD=1
 endif
 
+ifeq ($(ENABLE_RADIANT_CONSOLE),1)
+	ALL_CPPFLAGS += -DENABLE_RADIANT_CONSOLE=1
+endif
+
 ifeq ($(PLATFORM),darwin)
 	ALL_CPPFLAGS += -I/opt/local/include
 endif
@@ -174,6 +178,12 @@ TTF_LIBS := -lSDL2_ttf
 
 ALL_LIBS := $(HMD_LIBS) $(TILT_LIBS) $(INTL_LIBS) $(TTF_LIBS) \
 	$(OGG_LIBS) $(SDL_LIBS) $(OGL_LIBS) $(BASE_LIBS)
+
+MAPC_LIBS := $(BASE_LIBS)
+
+ifeq ($(ENABLE_RADIANT_CONSOLE),1)
+	MAPC_LIBS += -lSDL2_net
+endif
 
 #------------------------------------------------------------------------------
 
@@ -407,7 +417,7 @@ $(PUTT_TARG) : $(PUTT_OBJS)
 	$(LINK) -o $(PUTT_TARG) $(PUTT_OBJS) $(LDFLAGS) $(ALL_LIBS)
 
 $(MAPC_TARG) : $(MAPC_OBJS)
-	$(CC) $(ALL_CFLAGS) -o $(MAPC_TARG) $(MAPC_OBJS) $(LDFLAGS) $(BASE_LIBS)
+	$(CC) $(ALL_CFLAGS) -o $(MAPC_TARG) $(MAPC_OBJS) $(LDFLAGS) $(MAPC_LIBS)
 
 # Work around some extremely helpful sdl-config scripts.
 

--- a/NeverballPack/games/neverball.game
+++ b/NeverballPack/games/neverball.game
@@ -23,5 +23,4 @@
   entities="quake3"
   brushtypes="quake3"
   patchtypes="quake3"
-  no_bsp_monitor="1"
 />

--- a/NeverballPack/neverball.game/default_build_menu.xml
+++ b/NeverballPack/neverball.game/default_build_menu.xml
@@ -10,21 +10,22 @@ build commands
 <var name="neverball">"[EnginePath]neverball"</var>
 <var name="neverputt">"[EnginePath]neverputt"</var>
 <var name="data">"[EnginePath][GameName]"</var>
+<var name="opts">--bcast</var>
 <build name="Compile">
-<command>[mapc] "[MapFile]" [data]</command>
+<command>[mapc] "[MapFile]" [data] [opts]</command>
 </build>
 <build name="Neverball: play">
 <command>[neverball] "[MapFile]"</command>
 </build>
 <build name="Neverball: compile+play">
-<command>[mapc] "[MapFile]" [data]</command>
+<command>[mapc] "[MapFile]" [data] [opts]</command>
 <command>[neverball] "[MapFile]"</command>
 </build>
 <build name="Neverputt: play">
 <command>[neverputt] "[MapFile]"</command>
 </build>
 <build name="Neverputt: compile+play">
-<command>[mapc] "[MapFile]" [data]</command>
+<command>[mapc] "[MapFile]" [data] [opts]</command>
 <command>[neverputt] "[MapFile]"</command>
 </build>
 </project>


### PR DESCRIPTION
It is what it says. I looked at the Q3Map BSP monitoring protocol and added very basic support to mapc. It requires SDL2_net and is not compiled in by default. It is hardly useful unless mapc is launched from the Radiant build menu. NeverballPack does provide menu entries for that, but you'll have to reinstall the gamepack, because the game description file has changed. And finally, build monitoring has to be enabled in Radiant preferences for this to work.
