### PR TITLE
Make putt keyboard controls less sticky

### DIFF
--- a/putt/main.c
+++ b/putt/main.c
@@ -225,7 +225,12 @@ static int loop(void)
             break;
 
         case SDL_JOYBUTTONDOWN:
-            reset_axes();
+            /* Do not reset unless an action button is pressed */
+            if (e.jbutton.button == config_get_d(CONFIG_JOYSTICK_BUTTON_A) ||
+                e.jbutton.button == config_get_d(CONFIG_JOYSTICK_BUTTON_START))
+            {
+                reset_axes();
+            }
 
             d = st_buttn(e.jbutton.button, 1);
             break;


### PR DESCRIPTION
In Neverputt 1.5.X, if a player kept a movement axis held as he or she was putting (or pausing), the axes stick, causing the ball to aim on its own accord even after the putt until the movement controls were touched again.

With this bug fix I coded and propose to merge, the axes are returned to neutral as a ball is putted or the game is paused, avoiding the sticky controls of the past.
