### PR TITLE
Reset power controls after leaving a stroke

### DIFF
--- a/putt/st_all.c
+++ b/putt/st_all.c
@@ -955,6 +955,7 @@ static void stroke_leave(struct state *st, struct state *next, int id)
     video_clr_grab();
     config_set_d(CONFIG_CAMERA, 0);
     stroke_rotate = 0.0f;
+    stroke_mag = 0.0f;
 }
 
 static void stroke_paint(int id, float t)


### PR DESCRIPTION
Reset power controls, in addition to angle controls, after leaving a stroke
