### PR TITLE
Make right mouse button behave like Escape to make mouse only play possi...

### DIFF
--- a/ball/st_demo.c
+++ b/ball/st_demo.c
@@ -534,6 +534,16 @@ static void demo_play_wheel(int x, int y)
     if (y < 0) set_speed(-1);
 }
 
+static int demo_play_click(int b, int d)
+{
+    if (b == SDL_BUTTON_RIGHT && d == 1)
+    {
+        demo_paused = 1;
+        return goto_state(&st_demo_end);
+    }
+    return 1;
+}
+
 static int demo_play_keybd(int c, int d)
 {
     if (d)
@@ -827,7 +837,7 @@ struct state st_demo_play = {
     NULL,
     demo_play_stick,
     NULL,
-    NULL,
+    demo_play_click,
     demo_play_keybd,
     demo_play_buttn,
     demo_play_wheel

--- a/ball/st_help.c
+++ b/ball/st_help.c
@@ -420,6 +420,15 @@ static void help_demo_timer(int id, float dt)
     game_client_blend(demo_replay_blend());
 }
 
+static int help_demo_click(int b, int d)
+{
+    if (b == SDL_BUTTON_RIGHT && d == 1)
+    {
+        return goto_state(&st_help);
+    }
+    return 1;
+}
+
 static int help_demo_keybd(int c, int d)
 {
     if (d)
@@ -462,7 +471,7 @@ struct state st_help_demo = {
     NULL,
     NULL,
     NULL,
-    NULL,
+    help_demo_click,
     help_demo_keybd,
     help_demo_buttn
 };

--- a/ball/st_level.c
+++ b/ball/st_level.c
@@ -107,7 +107,16 @@ static void level_timer(int id, float dt)
 
 static int level_click(int b, int d)
 {
-    return (b == SDL_BUTTON_LEFT && d == 1) ? goto_state(&st_play_ready) : 1;
+    if (b == SDL_BUTTON_LEFT && d == 1)
+    {
+        return goto_state(&st_play_ready);
+    }
+    else if (b == SDL_BUTTON_RIGHT && d == 1)
+    {
+        progress_stop();
+        return goto_state(&st_exit);
+    }
+    return 1;
 }
 
 static int level_keybd(int c, int d)

--- a/ball/st_over.c
+++ b/ball/st_over.c
@@ -61,7 +61,8 @@ static void over_timer(int id, float dt)
 
 static int over_click(int b, int d)
 {
-    return (b == SDL_BUTTON_LEFT && d == 1) ? goto_state(&st_exit) : 1;
+    return ((b == SDL_BUTTON_LEFT || b == SDL_BUTTON_RIGHT) && d == 1) ?
+            goto_state(&st_exit) : 1;
 }
 
 static int over_keybd(int c, int d)

--- a/ball/st_shared.c
+++ b/ball/st_shared.c
@@ -90,6 +90,8 @@ int shared_click(int b, int d)
 
     if (gui_click(b, d))
         return st_buttn(config_get_d(CONFIG_JOYSTICK_BUTTON_A), 1);
+    else if(gui_click_right(b, d))
+        return st_buttn(config_get_d(CONFIG_JOYSTICK_BUTTON_B), 1);
     else
         return 1;
 }

--- a/ball/st_start.c
+++ b/ball/st_start.c
@@ -336,6 +336,10 @@ static int start_click(int b, int d)
     {
         return start_buttn(config_get_d(CONFIG_JOYSTICK_BUTTON_A), 1);
     }
+    else if (gui_click_right(b, d))
+    {
+        return start_buttn(config_get_d(CONFIG_JOYSTICK_BUTTON_B), 1);
+    }
     return 1;
 }
 

--- a/doc/manual.txt
+++ b/doc/manual.txt
@@ -232,6 +232,11 @@ values follow.
         seconds,  so the  actual rotation  rate depends  upon view_dz,
         above.  The fast rate is used when the Shift key is held down.
 
+    rotate_timeout 3500
+
+        Timeout in milliseconds before right button performs Escape.
+        The default is 3500 milliseconds (3.5 seconds).  0 is off.
+
     fps 0
 
         This key enables an on-screen frames-per-second counter. Press

--- a/putt/st_all.c
+++ b/putt/st_all.c
@@ -288,7 +288,11 @@ static void title_point(int id, int x, int y, int dx, int dy)
 
 static int title_click(int b, int d)
 {
-    return gui_click(b, d) ? title_action(gui_token(gui_active())) : 1;
+    if (gui_click(b, d))
+        return title_action(gui_token(gui_active()));
+    else if (gui_click_right(b, d))
+        return title_action(TITLE_EXIT);
+    return 1;
 }
 
 static int title_buttn(int b, int d)
@@ -464,7 +468,11 @@ static void course_stick(int id, int a, float v, int bump)
 
 static int course_click(int b, int d)
 {
-    return gui_click(b, d) ? course_action(gui_token(gui_active())) : 1;
+    if ( gui_click(b, d))
+        return course_action(gui_token(gui_active()));
+    else if ( gui_click_right(b, d))
+        return course_action(COURSE_BACK);
+    return 1;
 }
 
 static int course_buttn(int b, int d)
@@ -581,7 +589,11 @@ static void party_point(int id, int x, int y, int dx, int dy)
 
 static int party_click(int b, int d)
 {
-    return gui_click(b, d) ? party_action(gui_token(gui_active())) : 1;
+    if (gui_click(b, d))
+        return party_action(gui_token(gui_active()));
+    else if (gui_click_right(b, d))
+        return party_action(PARTY_B);
+    return 1;
 }
 
 static int party_buttn(int b, int d)
@@ -684,7 +696,11 @@ static void pause_point(int id, int x, int y, int dx, int dy)
 
 static int pause_click(int b, int d)
 {
-    return gui_click(b, d) ? pause_action(gui_token(gui_active())) : 1;
+    if (gui_click(b, d))
+        return pause_action(gui_token(gui_active()));
+    else if (gui_click_right(b, d))
+        return pause_action(PAUSE_CONTINUE);
+    return 1;
 }
 
 static int pause_keybd(int c, int d)
@@ -798,7 +814,15 @@ static void next_point(int id, int x, int y, int dx, int dy)
 
 static int next_click(int b, int d)
 {
-    return (d && b == SDL_BUTTON_LEFT) ? goto_state(&st_flyby) : 1;
+    if (d && b == SDL_BUTTON_LEFT)
+    {
+        return goto_state(&st_flyby);
+    }
+    else if (d && b == SDL_BUTTON_RIGHT)
+    {
+        return goto_pause(&st_over);
+    }
+    return 1;
 }
 
 static int next_keybd(int c, int d)
@@ -912,6 +936,10 @@ static int flyby_click(int b, int d)
         game_set_fly(0.f);
         return goto_state(&st_stroke);
     }
+    else if (d && b == SDL_BUTTON_RIGHT)
+    {
+        return goto_pause(&st_over);
+    }
     return 1;
 }
 
@@ -1000,7 +1028,11 @@ static void stroke_stick(int id, int a, float v, int bump)
 
 static int stroke_click(int b, int d)
 {
-    return (d && b == SDL_BUTTON_LEFT) ? goto_state(&st_roll) : 1;
+    if (d && b == SDL_BUTTON_LEFT)
+        return goto_state(&st_roll);
+    else if (d && b == SDL_BUTTON_RIGHT)
+        return goto_pause(&st_over);
+    return 1;
 }
 
 static int stroke_buttn(int b, int d)
@@ -1051,6 +1083,14 @@ static void roll_timer(int id, float dt)
     case GAME_STOP: goto_state(&st_stop); break;
     case GAME_GOAL: goto_state(&st_goal); break;
     case GAME_FALL: goto_state(&st_fall); break;
+    }
+}
+
+static int roll_click(int b, int d)
+{
+    if (d && b == SDL_BUTTON_RIGHT)
+    {
+        return goto_pause(&st_over);
     }
 }
 
@@ -1116,6 +1156,10 @@ static int goal_click(int b, int d)
             goto_state(&st_next);
         else
             goto_state(&st_score);
+    }
+    else if (b == SDL_BUTTON_RIGHT && d == 1)
+    {
+        return goto_pause(&st_over);
     }
     return 1;
 }
@@ -1186,6 +1230,10 @@ static int stop_click(int b, int d)
             goto_state(&st_next);
         else
             goto_state(&st_score);
+    }
+    else if (b == SDL_BUTTON_RIGHT && d == 1)
+    {
+        return goto_pause(&st_over);
     }
     return 1;
 }
@@ -1263,6 +1311,10 @@ static int fall_click(int b, int d)
         else
             goto_state(&st_score);
     }
+    else if (b == SDL_BUTTON_RIGHT && d == 1)
+    {
+        return goto_pause(&st_over);
+    }
     return 1;
 }
 
@@ -1320,6 +1372,10 @@ static int score_click(int b, int d)
         else
             return goto_state(&st_title);
     }
+    else if (b == SDL_BUTTON_RIGHT && d == 1)
+    {
+        return goto_pause(&st_over);
+    }
     return 1;
 }
 
@@ -1366,7 +1422,7 @@ static void over_timer(int id, float dt)
 
 static int over_click(int b, int d)
 {
-    return (d && b == SDL_BUTTON_LEFT) ? goto_state(&st_title) : 1;
+    return (d && (b == SDL_BUTTON_LEFT || b == SDL_BUTTON_RIGHT)) ? goto_state(&st_title) : 1;
 }
 
 static int over_buttn(int b, int d)
@@ -1482,7 +1538,7 @@ struct state st_roll = {
     NULL,
     NULL,
     NULL,
-    NULL,
+    roll_click,
     shared_keybd,
     roll_buttn
 };

--- a/putt/st_conf.c
+++ b/putt/st_conf.c
@@ -203,6 +203,8 @@ static int conf_click(int b, int d)
 {
     if (gui_click(b, d))
         return conf_action(gui_token(gui_active()));
+    else if (gui_click_right(b, d))
+        return goto_state(&st_title);
 
     return 1;
 }

--- a/share/config.c
+++ b/share/config.c
@@ -102,6 +102,7 @@ int CONFIG_VIEW_DC;
 int CONFIG_VIEW_DZ;
 int CONFIG_ROTATE_FAST;
 int CONFIG_ROTATE_SLOW;
+int CONFIG_ROTATE_TIMEOUT;
 int CONFIG_CHEAT;
 int CONFIG_STATS;
 int CONFIG_SCREENSHOT;
@@ -202,16 +203,17 @@ static struct
     { &CONFIG_KEY_SCORE_NEXT,    "key_score_next",    SDLK_TAB },
     { &CONFIG_KEY_ROTATE_FAST,   "key_rotate_fast",   SDLK_LSHIFT },
 
-    { &CONFIG_VIEW_FOV,    "view_fov",    50 },
-    { &CONFIG_VIEW_DP,     "view_dp",     75 },
-    { &CONFIG_VIEW_DC,     "view_dc",     25 },
-    { &CONFIG_VIEW_DZ,     "view_dz",     200 },
-    { &CONFIG_ROTATE_FAST, "rotate_fast", 300 },
-    { &CONFIG_ROTATE_SLOW, "rotate_slow", 150 },
-    { &CONFIG_CHEAT,       "cheat",       0 },
-    { &CONFIG_STATS,       "stats",       0 },
-    { &CONFIG_SCREENSHOT,  "screenshot",  0 },
-    { &CONFIG_LOCK_GOALS,  "lock_goals",  0 },
+    { &CONFIG_VIEW_FOV,       "view_fov",       50 },
+    { &CONFIG_VIEW_DP,        "view_dp",        75 },
+    { &CONFIG_VIEW_DC,        "view_dc",        25 },
+    { &CONFIG_VIEW_DZ,        "view_dz",        200 },
+    { &CONFIG_ROTATE_FAST,    "rotate_fast",    300 },
+    { &CONFIG_ROTATE_SLOW,    "rotate_slow",    150 },
+    { &CONFIG_ROTATE_TIMEOUT, "rotate_timeout", 3500 },
+    { &CONFIG_CHEAT,          "cheat",          0 },
+    { &CONFIG_STATS,          "stats",          0 },
+    { &CONFIG_SCREENSHOT,     "screenshot",     0 },
+    { &CONFIG_LOCK_GOALS,     "lock_goals",     0 },
 
     { &CONFIG_CAMERA_1_SPEED, "camera_1_speed", 250 },
     { &CONFIG_CAMERA_2_SPEED, "camera_2_speed", 0 },

--- a/share/config.h
+++ b/share/config.h
@@ -99,6 +99,7 @@ extern int CONFIG_VIEW_DC;
 extern int CONFIG_VIEW_DZ;
 extern int CONFIG_ROTATE_FAST;
 extern int CONFIG_ROTATE_SLOW;
+extern int CONFIG_ROTATE_TIMEOUT;
 extern int CONFIG_CHEAT;
 extern int CONFIG_STATS;
 extern int CONFIG_SCREENSHOT;

--- a/share/gui.c
+++ b/share/gui.c
@@ -2171,6 +2171,15 @@ int gui_click(int b, int d)
     return 0;
 }
 
+int gui_click_right(int b, int d)
+{
+    if (b == SDL_BUTTON_RIGHT && d)
+    {
+        return 1;
+    }
+    return 0;
+}
+
 /*---------------------------------------------------------------------------*/
 
 int gui_navig(int id, int total, int first, int step)

--- a/share/gui.h
+++ b/share/gui.h
@@ -116,6 +116,7 @@ void gui_timer(int, float);
 int  gui_point(int, int, int);
 int  gui_stick(int, int, float, int);
 int  gui_click(int, int);
+int  gui_click_right(int, int);
 void gui_focus(int);
 
 int  gui_active(void);

--- a/share/st_common.c
+++ b/share/st_common.c
@@ -167,6 +167,10 @@ int common_click(int b, int d)
         int active = gui_active();
         return common_action(gui_token(active), gui_value(active));
     }
+    else if (gui_click_right(b, d))
+    {
+        return common_action(GUI_BACK, 0);
+    }
     return 1;
 }
 


### PR DESCRIPTION
...ble.  Affects both the neverball and neverputt.  In neverball the right mouse button rotates the camera so holding the right mouse button for a configurable time performs Escape during neverball play.

This is a working example of the right mouse button to Escape as suggested on the forums.  http://forum.nevercorner.net/viewtopic.php?id=2860

Many applications such as xbmc do this.
