### PR TITLE
neverputt: Add KEY_FALL as SDL_TAB to call goto_state(&st_fall) to take penalty and...

### DIFF
--- a/putt/st_all.c
+++ b/putt/st_all.c
@@ -691,6 +691,8 @@ static int pause_keybd(int c, int d)
 {
     if (d && c == KEY_EXIT)
         return pause_action(PAUSE_CONTINUE);
+      if (d && c == KEY_FALL)
+	goto_state(&st_fall);
     return 1;
 }
 
@@ -713,8 +715,10 @@ static int shared_keybd(int c, int d)
 {
     if (d)
     {
-        if (c == KEY_EXIT)
-            return goto_pause(&st_over);
+      if (c == KEY_EXIT)
+	return goto_pause(&st_over);
+      if (c == KEY_FALL)
+	goto_state(&st_fall);
     }
     return 1;
 }
@@ -805,12 +809,14 @@ static int next_keybd(int c, int d)
 {
     if (d)
     {
-        if (c == KEY_POSE)
-            return goto_state(&st_poser);
-        if (c == KEY_EXIT)
-            return goto_pause(&st_over);
-        if ('0' <= c && c <= '9')
-            num = num * 10 + c - '0';
+      if (c == KEY_POSE)
+	return goto_state(&st_poser);
+      if (c == KEY_EXIT)
+	return goto_pause(&st_over);
+      if (c == KEY_FALL)
+	goto_state(&st_fall);
+      if ('0' <= c && c <= '9')
+	num = num * 10 + c - '0';
     }
     return 1;
 }

--- a/share/config.h
+++ b/share/config.h
@@ -147,7 +147,7 @@ int config_screenshot(void);
 /* Names for some hard-coded keys. */
 
 #define KEY_EXIT       SDLK_ESCAPE
-
+#define KEY_FALL       SDLK_TAB
 #define KEY_LOOKAROUND SDLK_F5
 #define KEY_WIREFRAME  SDLK_F6
 #define KEY_RESOURCES  SDLK_F7


### PR DESCRIPTION
... continue.
This is for Neverputt.
When the ball is on top of a moving object, the game cannot continue.
This patch allows the TAB to force the st_fall routine, causing the penalty 
and continuing to to the next player.