### PR TITLE
Change default aniso to 8, check for GL extension

### DIFF
--- a/share/config.c
+++ b/share/config.c
@@ -139,7 +139,7 @@ static struct
     { &CONFIG_REFLECTION,   "reflection",   1 },
     { &CONFIG_MULTISAMPLE,  "multisample",  0 },
     { &CONFIG_MIPMAP,       "mipmap",       1 },
-    { &CONFIG_ANISO,        "aniso",        0 },
+    { &CONFIG_ANISO,        "aniso",        8 },
     { &CONFIG_BACKGROUND,   "background",   1 },
     { &CONFIG_SHADOW,       "shadow",       1 },
     { &CONFIG_AUDIO_BUFF,   "audio_buff",   AUDIO_BUFF_HI },

--- a/share/glext.c
+++ b/share/glext.c
@@ -123,6 +123,9 @@ int glext_init(void)
     glGetIntegerv(GL_MAX_TEXTURE_SIZE,  &gli.max_texture_size);
     glGetIntegerv(GL_MAX_TEXTURE_UNITS, &gli.max_texture_units);
 
+    if (glext_check("GL_EXT_texture_filter_anisotropic"))
+        gli.aniso_filtering = 1;
+
     /* Desktop init. */
 
 #if !ENABLE_OPENGLES
@@ -186,9 +189,6 @@ int glext_init(void)
 
     if (glext_check("GREMEDY_string_marker"))
         SDL_GL_GFPA(glStringMarkerGREMEDY_, "glStringMarkerGREMEDY");
-
-    if (glext_check("GL_EXT_texture_filter_anisotropic"))
-        gli.aniso_filtering = 1;
 
 #endif
 

--- a/share/glext.c
+++ b/share/glext.c
@@ -187,6 +187,9 @@ int glext_init(void)
     if (glext_check("GREMEDY_string_marker"))
         SDL_GL_GFPA(glStringMarkerGREMEDY_, "glStringMarkerGREMEDY");
 
+    if (glext_check("GL_EXT_texture_filter_anisotropic"))
+        gli.aniso_filtering = 1;
+
 #endif
 
     return 1;

--- a/share/glext.c
+++ b/share/glext.c
@@ -124,7 +124,7 @@ int glext_init(void)
     glGetIntegerv(GL_MAX_TEXTURE_UNITS, &gli.max_texture_units);
 
     if (glext_check("GL_EXT_texture_filter_anisotropic"))
-        gli.aniso_filtering = 1;
+        gli.texture_filter_anisotropic = 1;
 
     /* Desktop init. */
 

--- a/share/glext.h
+++ b/share/glext.h
@@ -293,6 +293,7 @@ struct gl_info
     GLint max_texture_units;
     GLint max_texture_size;
 
+    unsigned int aniso_filtering    : 1;
     unsigned int shader_objects     : 1;
     unsigned int framebuffer_object : 1;
 };

--- a/share/glext.h
+++ b/share/glext.h
@@ -293,9 +293,9 @@ struct gl_info
     GLint max_texture_units;
     GLint max_texture_size;
 
-    unsigned int aniso_filtering    : 1;
-    unsigned int shader_objects     : 1;
-    unsigned int framebuffer_object : 1;
+    unsigned int texture_filter_anisotropic : 1;
+    unsigned int shader_objects             : 1;
+    unsigned int framebuffer_object         : 1;
 };
 
 extern struct gl_info gli;

--- a/share/image.c
+++ b/share/image.c
@@ -151,7 +151,7 @@ GLuint make_texture(const void *p, int w, int h, int b, int fl)
     }
 #endif
 #ifdef GL_TEXTURE_MAX_ANISOTROPY_EXT
-    if (a && gli.aniso_filtering) glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAX_ANISOTROPY_EXT, a);
+    if (a && gli.texture_filter_anisotropic) glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAX_ANISOTROPY_EXT, a);
 #endif
 
     /* Copy the image to an OpenGL texture. */

--- a/share/image.c
+++ b/share/image.c
@@ -112,7 +112,9 @@ GLuint make_texture(const void *p, int w, int h, int b, int fl)
     /* Scale the image as configured, or to fit the OpenGL limitations. */
 
 #ifdef GL_TEXTURE_MAX_ANISOTROPY_EXT
-    int a = config_get_d(CONFIG_ANISO);
+    int a = 0;
+    if (glext_check("GL_EXT_texture_filter_anisotropic"))
+        a = config_get_d(CONFIG_ANISO);
 #endif
 #ifdef GL_GENERATE_MIPMAP_SGIS
     int m = (fl & IF_MIPMAP) ? config_get_d(CONFIG_MIPMAP) : 0;

--- a/share/image.c
+++ b/share/image.c
@@ -112,9 +112,7 @@ GLuint make_texture(const void *p, int w, int h, int b, int fl)
     /* Scale the image as configured, or to fit the OpenGL limitations. */
 
 #ifdef GL_TEXTURE_MAX_ANISOTROPY_EXT
-    int a = 0;
-    if (glext_check("GL_EXT_texture_filter_anisotropic"))
-        a = config_get_d(CONFIG_ANISO);
+    int a = config_get_d(CONFIG_ANISO);
 #endif
 #ifdef GL_GENERATE_MIPMAP_SGIS
     int m = (fl & IF_MIPMAP) ? config_get_d(CONFIG_MIPMAP) : 0;
@@ -153,7 +151,7 @@ GLuint make_texture(const void *p, int w, int h, int b, int fl)
     }
 #endif
 #ifdef GL_TEXTURE_MAX_ANISOTROPY_EXT
-    if (a) glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAX_ANISOTROPY_EXT, a);
+    if (a && gli.aniso_filtering) glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAX_ANISOTROPY_EXT, a);
 #endif
 
     /* Copy the image to an OpenGL texture. */


### PR DESCRIPTION
I've done two things here.

First, check for the presence of GL_EXT_texture_filter_anisotropic before using it.

Second, I changed the default aniso value from 0 to 8. IMO, a long overdue change. Neverball isn't a demanding game, and AF has been supported on low-range cards with (almost) no performance penalty for half a decade or longer. Given that, I suggest quality be the default :)