### PR TITLE
Make OpenGL ES work out of the box via the Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -74,6 +74,10 @@ ALL_CPPFLAGS += \
 	-DCONFIG_DATA=\"$(DATADIR)\" \
 	-DCONFIG_LOCALE=\"$(LOCALEDIR)\"
 
+ifeq ($(ENABLE_OPENGLES),1)
+	ALL_CPPFLAGS += -DENABLE_OPENGLES=1
+endif
+
 ifeq ($(ENABLE_NLS),0)
 	ALL_CPPFLAGS += -DENABLE_NLS=0
 else
@@ -152,7 +156,11 @@ endif
 endif
 endif
 
-OGL_LIBS := -lGL
+ifeq ($(ENABLE_OPENGLES),1)
+	OGL_LIBS := -lGLESv1_CM
+else
+	OGL_LIBS := -lGL
+endif
 
 ifeq ($(PLATFORM),mingw)
 	ifneq ($(ENABLE_NLS),0)

--- a/share/glext.c
+++ b/share/glext.c
@@ -106,6 +106,18 @@ int glext_assert(const char *ext)
 
 /*---------------------------------------------------------------------------*/
 
+static void log_opengl(void)
+{
+    log_printf("GL vendor: %s\n"
+               "GL renderer: %s\n"
+               "GL version: %s\n"
+               "GL extensions: %s",
+               glGetString(GL_VENDOR),
+               glGetString(GL_RENDERER),
+               glGetString(GL_VERSION),
+               glGetString(GL_EXTENSIONS));
+}
+
 int glext_fail(const char *title, const char *message)
 {
     SDL_ShowSimpleMessageBox(SDL_MESSAGEBOX_ERROR, title, message, NULL);
@@ -114,8 +126,6 @@ int glext_fail(const char *title, const char *message)
 
 int glext_init(void)
 {
-    void *ptr = 0;
-
     memset(&gli, 0, sizeof (struct gl_info));
 
     /* Common init. */
@@ -129,6 +139,7 @@ int glext_init(void)
     /* Desktop init. */
 
 #if !ENABLE_OPENGLES
+    void *ptr = 0;
 
     if (glext_assert("ARB_multitexture"))
     {
@@ -191,6 +202,8 @@ int glext_init(void)
         SDL_GL_GFPA(glStringMarkerGREMEDY_, "glStringMarkerGREMEDY");
 
 #endif
+
+    log_opengl();
 
     return 1;
 }

--- a/share/glext.h
+++ b/share/glext.h
@@ -23,6 +23,12 @@
 #include <windows.h>
 #endif
 
+#if ENABLE_OPENGLES
+
+#include <GLES/gl.h>
+
+#else  /* ENABLE_OPENGLES */
+
 #ifdef __APPLE__
 #include <OpenGL/gl.h>
 #else
@@ -32,6 +38,8 @@
 #ifdef _WIN32
 #include <GL/glext.h>
 #endif
+
+#endif  /* ENABLE_OPENGLES */
 
 /* Windows calling convention cruft. */
 
@@ -155,11 +163,7 @@ int glext_init(void);
 /* of the extensions we use. Otherwise, GetProc them regardless of whether   */
 /* they need it or not.                                                      */
 
-#if defined(GL_VERSION_ES_CM_1_0) || \
-    defined(GL_VERSION_ES_CM_1_1) || \
-    defined(GL_OES_VERSION_1_0)
-
-#define ENABLE_OPENGLES 1
+#if ENABLE_OPENGLES
 
 #define glClientActiveTexture_ glClientActiveTexture
 #define glActiveTexture_       glActiveTexture
@@ -170,6 +174,7 @@ int glext_init(void);
 #define glDeleteBuffers_       glDeleteBuffers
 #define glIsBuffer_            glIsBuffer
 #define glPointParameterfv_    glPointParameterfv
+#define glPointParameterf_     glPointParameterf
 
 #define glOrtho_               glOrthof
 

--- a/share/video.c
+++ b/share/video.c
@@ -154,6 +154,12 @@ int video_mode(int f, int w, int h)
         SDL_DestroyWindow(window);
     }
 
+#if ENABLE_OPENGLES
+    SDL_GL_SetAttribute(SDL_GL_CONTEXT_PROFILE_MASK, SDL_GL_CONTEXT_PROFILE_ES);
+    SDL_GL_SetAttribute(SDL_GL_CONTEXT_MAJOR_VERSION, 1);
+    SDL_GL_SetAttribute(SDL_GL_CONTEXT_MINOR_VERSION, 1);
+#endif
+
     SDL_GL_SetAttribute(SDL_GL_STEREO,             stereo);
     SDL_GL_SetAttribute(SDL_GL_STENCIL_SIZE,       stencil);
     SDL_GL_SetAttribute(SDL_GL_MULTISAMPLEBUFFERS, buffers);


### PR DESCRIPTION
I managed to figure it out. With the particle code disabled, the stars change to squares but I guess this is expected. Apart from that, I can see two other differences that are probably glitches.

The chequerboard effect you get on the Neverball letters in the intro is missing and the lack of environment mapping makes weird circles appear on many surfaces. You can see the latter when using regular OpenGL by explicitly disabling the environment mapping code in solid_draw.c.

As you can probably tell, my OpenGL knowledge is very limited. I made a simple 3D maze in a class in 2004 once. :grin: 
