### PR TITLE
Require keyup event before accepting keydown in GUI

### DIFF
--- a/ball/st_play.c
+++ b/ball/st_play.c
@@ -426,6 +426,10 @@ static void play_loop_point(int id, int x, int y, int dx, int dy)
 
 static void play_loop_stick(int id, int a, float v, int bump)
 {
+    if (v == 0)
+        gui_unfreeze();
+    else
+        gui_freeze();
     if (config_tst_d(CONFIG_JOYSTICK_AXIS_X0, a))
         game_set_z(v);
     if (config_tst_d(CONFIG_JOYSTICK_AXIS_Y0, a))

--- a/share/gui.c
+++ b/share/gui.c
@@ -101,6 +101,7 @@ struct widget
 
 static struct widget widget[WIDGET_MAX];
 static int           active;
+static int           frozen;
 static int           hovered;
 static int           clicked;
 static int           padding;
@@ -566,6 +567,7 @@ void gui_init(void)
         gui_layout(cursor_id, 0, 0);
 
     active = 0;
+    frozen = 0;
 }
 
 void gui_free(void)
@@ -1839,6 +1841,16 @@ int gui_active(void)
     return active;
 }
 
+void gui_freeze(void)
+{
+    frozen = 1;
+}
+
+void gui_unfreeze(void)
+{
+    frozen = 0;
+}
+
 int gui_token(int id)
 {
     return id ? widget[id].token : 0;
@@ -2124,6 +2136,13 @@ static int gui_wrap_D(int id, int dd)
 int gui_stick(int id, int a, float v, int bump)
 {
     int jd = 0;
+
+    if (frozen)
+    {
+        if (v == 0)
+            gui_unfreeze();
+        return 0;
+    }
 
     if (!bump)
         return 0;

--- a/share/gui.h
+++ b/share/gui.h
@@ -117,6 +117,8 @@ int  gui_point(int, int, int);
 int  gui_stick(int, int, float, int);
 int  gui_click(int, int);
 void gui_focus(int);
+void gui_freeze(void);
+void gui_unfreeze(void);
 
 int  gui_active(void);
 int  gui_token(int);


### PR DESCRIPTION
Sometimes a user will be holding down an arrow key when the game ends. When this happens, the GUI immediately starts recognizing keydown events and changes the selected button on the GUI. This leads to a usability problem when a user wants to quickly retry a level (by hitting enter repeatedly). The user ends up saving a replay instead. I have over 50 accidentally saved replays because of this bug.

This pull requests solves the problem by freezing the GUI (i.e. makes it insensitive to keyboard events) whenever there's a keydown event in-game. It unfreezes it whenever there's a keyup event, whether in-game or back in the GUI. So if the game ends before a keyup event, the keyboard input to the GUI will be frozen until the keyup event happens, preventing the unwanted change of focus. As far as I can tell, this change has no side effects.

Thanks!