### PR TITLE
Log warnings on missing images and GL functions

### DIFF
--- a/share/geom.c
+++ b/share/geom.c
@@ -445,6 +445,8 @@ void back_init(const char *name)
     {
         struct mtrl *mp = mtrl_get(back.base.mtrls[0]);
         mp->o = make_image_from_file(name, IF_MIPMAP);
+        if (!mp->o)
+            log_printf("failed to load background image \"%s\"\n", name);
         glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_S, GL_REPEAT);
         back_state = 1;
     }

--- a/share/glext.c
+++ b/share/glext.c
@@ -99,9 +99,11 @@ int glext_assert(const char *ext)
 
 /*---------------------------------------------------------------------------*/
 
-#define SDL_GL_GFPA(fun, str) do {       \
-    ptr = SDL_GL_GetProcAddress(str);    \
-    memcpy(&fun, &ptr, sizeof (void *)); \
+#define SDL_GL_GFPA(fun, str) do {                       \
+    ptr = SDL_GL_GetProcAddress(str);                    \
+    if (!ptr)                                            \
+        log_printf("Missing OpenGL function %s\n", str); \
+    memcpy(&fun, &ptr, sizeof (void *));                 \
 } while(0)
 
 /*---------------------------------------------------------------------------*/
@@ -111,7 +113,7 @@ static void log_opengl(void)
     log_printf("GL vendor: %s\n"
                "GL renderer: %s\n"
                "GL version: %s\n"
-               "GL extensions: %s",
+               "GL extensions: %s\n",
                glGetString(GL_VENDOR),
                glGetString(GL_RENDERER),
                glGetString(GL_VERSION),

--- a/share/mtrl.c
+++ b/share/mtrl.c
@@ -104,12 +104,12 @@ static void load_mtrl_objects(struct mtrl *mp)
 {
     /* Make sure not to leak an already loaded object. */
 
-    if (mp->o)
+    if (mp->o || mp->base.f[0] == '\0')
         return;
 
     /* Load the texture. */
 
-    if ((mp->o = find_texture(_(mp->base.f))))
+    if ((mp->o = find_texture(_(mp->base.f))))  /* Why is the _() needed here? */
     {
         /* Set the texture to clamp or repeat based on material type. */
 
@@ -123,6 +123,8 @@ static void load_mtrl_objects(struct mtrl *mp)
         else
             glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_T, GL_REPEAT);
     }
+    else
+        log_printf("failed to load texture \"%s\"\n", mp->base.f);
 }
 
 /*


### PR DESCRIPTION
I've come across some level packs (such as penma's that have missing textures that appear white in-game, so this is to help diagnose that.

Most maps seem to reference this material called "default", which I assume is supposed to be this, and that triggers lots of warnings from mapc when building the maps.
https://github.com/Neverball/neverball/blob/master/share/mtrl.c#L51