### PR TITLE
Clear the log's file handle after closing it.

### DIFF
--- a/share/log.c
+++ b/share/log.c
@@ -89,6 +89,8 @@ void log_quit(void)
     if (log_fp)
     {
         fs_close(log_fp);
+        log_fp = NULL;
+
         log_header[0] = 0;
     }
 }


### PR DESCRIPTION
This is an incredibly pedantic change since you wouldn't expect to be logging anything after calling ```log_quit()```, and AFAICT ```log_quit()``` is never even called from putt or ball either, but for consistency I think that this should be cleared so that the logging system can be re-initialised to a new location if a client wanted to and so that multiple calls to ```log_quit()``` are a no-op rather than a crash.