### PR TITLE
Default cursor to first level in list

### DIFF
--- a/ball/st_start.c
+++ b/ball/st_start.c
@@ -66,7 +66,11 @@ static void gui_level(int id, int i)
         back = level_completed(l) ? fore    : gui_yel;
     }
 
-    jd = gui_label(id, level_name(l), GUI_SML, back, fore);
+    if (i == 0) {
+        jd = gui_start(id, level_name(l), GUI_SML, back, fore);
+    } else {
+        jd = gui_label(id, level_name(l), GUI_SML, back, fore);
+    }
 
     if (level_opened(l) || config_cheat())
         gui_set_state(jd, START_LEVEL, i);
@@ -171,7 +175,7 @@ static int start_gui(void)
 
             gui_label(jd, set_name(curr_set()), GUI_SML, gui_yel, gui_red);
             gui_filler(jd);
-            gui_start(jd, _("Back"),  GUI_SML, GUI_BACK, 0);
+            gui_state(jd, _("Back"),  GUI_SML, GUI_BACK, 0);
         }
 
         gui_space(id);


### PR DESCRIPTION
Changes the default cursor position to the first level in the list during the start screen. Allows smoother start process in particular for new users. Previously defaulted to the "Back" button, which meant a series of "clickthroughs" with the Enter button would loop the user back and forth.

![neverball](https://user-images.githubusercontent.com/19230462/55566745-91689700-56b9-11e9-92bd-45e8744738ac.png)