### PR TITLE
Default cursor to beginning of level set

### DIFF
--- a/ball/st_set.c
+++ b/ball/st_set.c
@@ -87,7 +87,10 @@ static int set_action(int tok, int val)
 static void gui_set(int id, int i)
 {
     if (set_exists(i))
-        gui_state(id, set_name(i), GUI_SML, SET_SELECT, i);
+        if (i % SET_STEP == 0)
+            gui_start(id, set_name(i), GUI_SML, SET_SELECT, i);
+        else
+            gui_state(id, set_name(i), GUI_SML, SET_SELECT, i);
     else
         gui_label(id, "", GUI_SML, 0, 0);
 }


### PR DESCRIPTION
Measures SET_STEP for to place the cursor on the first level on each page in the level set view. Second half of #182.

![neverball](https://user-images.githubusercontent.com/19230462/55606695-10e87b80-5737-11e9-9fd2-7d2ada9ac2e4.png)