### PR TITLE
XDG base directory specification

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -20,7 +20,7 @@ endif
 #------------------------------------------------------------------------------
 # Paths (packagers might want to set DATADIR and LOCALEDIR)
 
-USERDIR   := .neverball
+USERDIR   := neverball
 DATADIR   := ./data
 LOCALEDIR := ./locale
 

--- a/share/base_config.c
+++ b/share/base_config.c
@@ -70,7 +70,12 @@ static const char *pick_home_path(void)
 #else
     const char *path;
 
-    return (path = getenv("HOME")) ? path : fs_base_dir();
+    path = getenv("XDG_DATA_HOME");
+    if (!path)
+        path = getenv("HOME");
+    if (!path)
+        path = fs_base_dir();
+    return path;
 #endif
 }
 

--- a/share/base_config.h
+++ b/share/base_config.h
@@ -43,7 +43,7 @@
 #ifdef _WIN32
 #define CONFIG_USER   "Neverball"
 #else
-#define CONFIG_USER   ".neverball"
+#define CONFIG_USER   "neverball"
 #endif
 #endif
 


### PR DESCRIPTION
Two main changes:

1. Neverball should respect [XDG base directory](https://specifications.freedesktop.org/basedir-spec/basedir-spec-latest.html) for the data directory and use `XDG_DATA_HOME` environmental variable when available on Linux.

2. No more hidden data directory. Hiding the data directory as a dotfile becomes a problem when following XDG spec. Instead we should make the directory visible in the filesystem, the [same as it is in Windows](https://github.com/Neverball/neverball/blob/neverball-1.6.0/share/base_config.c#L61). Instead we should think about (future change) setting `path = ~/.local/share/neverball` when `XDG_DATA_HOME` is unset.