### PR TITLE
share/text.h: fix build failure against gcc-10

### DIFF
--- a/share/text.h
+++ b/share/text.h
@@ -15,7 +15,7 @@ int text_length(const char *);
 
 /*---------------------------------------------------------------------------*/
 
-char text_input[MAXSTR];
+extern char text_input[MAXSTR];
 
 void text_input_start(void (*cb)(int typing));
 void text_input_stop(void);


### PR DESCRIPTION
On gcc-10 (and gcc-9 -fno-common) build fails as:

```
cc .. -o neverball ...
ld: ball/st_save.o:(.bss+0x0):
  multiple definition of `text_input'; share/text.o:(.bss+0x0): first defined here
```

gcc-10 will change the default from -fcommon to fno-common:
https://gcc.gnu.org/PR85678.

The error also happens if CFLAGS=-fno-common passed explicitly.

Reported-by: Toralf Förster
Bug: https://bugs.gentoo.org/708050