### PR TITLE
Add touch support (Emscripten+mobile now actually playable)

### DIFF
--- a/ball/main.c
+++ b/ball/main.c
@@ -607,7 +607,9 @@ int main(int argc, char *argv[])
 
     /* Initialize SDL. */
 
+#ifdef SDL_HINT_TOUCH_MOUSE_EVENTS
     SDL_SetHint(SDL_HINT_TOUCH_MOUSE_EVENTS, "0");
+#endif
 
     if (SDL_Init(SDL_INIT_VIDEO | SDL_INIT_AUDIO | SDL_INIT_JOYSTICK) == -1)
     {

--- a/ball/main.c
+++ b/ball/main.c
@@ -270,6 +270,12 @@ static int loop(void)
             d = st_click(e.button.button, 0);
             break;
 
+        case SDL_FINGERDOWN:
+        case SDL_FINGERUP:
+        case SDL_FINGERMOTION:
+            d = st_touch(&e.tfinger);
+            break;
+
         case SDL_KEYDOWN:
             d = handle_key_dn(&e);
             break;
@@ -600,6 +606,8 @@ int main(int argc, char *argv[])
     make_dirs_and_migrate();
 
     /* Initialize SDL. */
+
+    SDL_SetHint(SDL_HINT_TOUCH_MOUSE_EVENTS, "0");
 
     if (SDL_Init(SDL_INIT_VIDEO | SDL_INIT_AUDIO | SDL_INIT_JOYSTICK) == -1)
     {

--- a/ball/st_play.c
+++ b/ball/st_play.c
@@ -537,6 +537,21 @@ static int play_loop_buttn(int b, int d)
     return 1;
 }
 
+static int play_loop_touch(const SDL_TouchFingerEvent *event)
+{
+    if (event->type == SDL_FINGERMOTION)
+    {
+        int dx = (int) ((float) video.device_w * event->dx);
+        int dy = (int) ((float) video.device_h * -event->dy);
+
+        game_set_pos(dx, dy);
+    }
+
+    // TODO: rotate camera, change camera, etc.
+
+    return 1;
+}
+
 /*---------------------------------------------------------------------------*/
 
 static float phi;
@@ -629,7 +644,9 @@ struct state st_play_loop = {
     shared_angle,
     play_loop_click,
     play_loop_keybd,
-    play_loop_buttn
+    play_loop_buttn,
+
+    .touch = play_loop_touch
 };
 
 struct state st_look = {

--- a/share/state.c
+++ b/share/state.c
@@ -265,4 +265,28 @@ int st_buttn(int b, int d)
     return (state && state->buttn) ? state->buttn(b, d) : 1;
 }
 
+int st_touch(const SDL_TouchFingerEvent *event)
+{
+    int d = 1;
+
+    /* If the state can handle it, do it. */
+
+    if (state && state->touch)
+        return state->touch(event);
+
+    /* Otherwise, emulate mouse events. */
+
+    st_point(video.device_w * event->x,
+             video.device_h * (1.0f - event->y),
+             video.device_w * event->dx,
+             video.device_h * -event->dy);
+
+    if (event->type == SDL_FINGERDOWN)
+        d = st_click(SDL_BUTTON_LEFT, 1);
+    else if (event->type == SDL_FINGERUP)
+        d = st_click(SDL_BUTTON_LEFT, 0);
+
+    return d;
+}
+
 /*---------------------------------------------------------------------------*/

--- a/share/state.h
+++ b/share/state.h
@@ -1,6 +1,8 @@
 #ifndef STATE_H
 #define STATE_H
 
+#include "SDL_events.h"
+
 /*---------------------------------------------------------------------------*/
 
 struct state
@@ -18,6 +20,8 @@ struct state
     void (*wheel)(int x,  int y);
 
     int gui_id;
+
+    int  (*touch)(const SDL_TouchFingerEvent *);
 };
 
 struct state *curr_state(void);
@@ -35,6 +39,7 @@ void st_wheel(int, int);
 int  st_click(int, int);
 int  st_keybd(int, int);
 int  st_buttn(int, int);
+int  st_touch(const SDL_TouchFingerEvent *);
 
 /*---------------------------------------------------------------------------*/
 


### PR DESCRIPTION
By default, SDL2/Emscripten creates synthetic mouse events from touch events, which worked great in the menus, but kinda broke down during gameplay. This patch disables that and just uses touch events directly.

The process is a bit convoluted, but check this out:

1) Go to parasti.github.io on your phone in landscape mode.
2) Go to Options to enable fullscreen. It's deferred, so it only activates when you leave that screen.
3) Play the game. Your phone's back button exits fullscreen first, but beyond that is usable for navigation/pause/etc.