### PR TITLE
Commands: replace tilt axes+angles with a quaternion

### DIFF
--- a/ball/game_client.c
+++ b/ball/game_client.c
@@ -163,6 +163,9 @@ static void game_run_cmd(const union cmd *cmd)
             break;
 
         case CMD_TILT_ANGLES:
+            tilt->rx = cmd->tiltangles.x;
+            tilt->rz = cmd->tiltangles.z;
+
             if (!cs.got_tilt_axes)
             {
                 /*
@@ -173,11 +176,14 @@ static void game_run_cmd(const union cmd *cmd)
                  * tilt axes, we use the view vectors.
                  */
 
-                game_tilt_axes(tilt, view->e);
+                game_tilt_calc(tilt, view->e);
             }
+            else
+            {
+                /* Use the axes we received via CMD_TILT_AXES. */
 
-            tilt->rx = cmd->tiltangles.x;
-            tilt->rz = cmd->tiltangles.z;
+                game_tilt_calc(tilt, NULL);
+            }
             break;
 
         case CMD_SOUND:
@@ -316,6 +322,10 @@ static void game_run_cmd(const union cmd *cmd)
             cs.got_tilt_axes = 1;
             v_cpy(tilt->x, cmd->tiltaxes.x);
             v_cpy(tilt->z, cmd->tiltaxes.z);
+            break;
+
+        case CMD_TILT:
+            q_cpy(tilt->q, cmd->tilt.q);
             break;
 
         case CMD_NONE:

--- a/ball/game_common.c
+++ b/ball/game_common.c
@@ -82,29 +82,36 @@ void game_tilt_init(struct game_tilt *tilt)
     tilt->z[2] = 1.0f;
 
     tilt->rz = 0.0f;
+
+    tilt->q[0] = 1.0f;
+    tilt->q[1] = 0.0f;
+    tilt->q[2] = 0.0f;
+    tilt->q[3] = 0.0f;
 }
 
 /*
- * Compute appropriate tilt axes from the view basis.
+ * Compute tilt orientation from tilt angles and the view basis.
  */
-void game_tilt_axes(struct game_tilt *tilt, float view_e[3][3])
+void game_tilt_calc(struct game_tilt *tilt, float view_e[3][3])
 {
-    v_cpy(tilt->x, view_e[0]);
-    v_cpy(tilt->z, view_e[2]);
+    float qx[4], qz[4];
+
+    if (view_e)
+    {
+        v_cpy(tilt->x, view_e[0]);
+        v_cpy(tilt->z, view_e[2]);
+    }
+
+    q_by_axisangle(qx, tilt->x, V_RAD(tilt->rx));
+    q_by_axisangle(qz, tilt->z, V_RAD(tilt->rz));
+
+    q_mul(tilt->q, qz, qx);
+    q_nrm(tilt->q, tilt->q);
 }
 
 void game_tilt_grav(float h[3], const float g[3], const struct game_tilt *tilt)
 {
-    float X[16];
-    float Z[16];
-    float M[16];
-
-    /* Compute the gravity vector from the given world rotations. */
-
-    m_rot (Z, tilt->z, V_RAD(tilt->rz));
-    m_rot (X, tilt->x, V_RAD(tilt->rx));
-    m_mult(M, Z, X);
-    m_vxfm(h, M, g);
+    q_rot(h, tilt->q, g);
 }
 
 /*---------------------------------------------------------------------------*/

--- a/ball/game_common.h
+++ b/ball/game_common.h
@@ -69,10 +69,12 @@ struct game_tilt
 {
     float x[3], rx;
     float z[3], rz;
+
+    float q[4];
 };
 
 void game_tilt_init(struct game_tilt *);
-void game_tilt_axes(struct game_tilt *, float view_e[3][3]);
+void game_tilt_calc(struct game_tilt *, float view_e[3][3]);
 void game_tilt_grav(float h[3], const float g[3], const struct game_tilt *);
 
 /*---------------------------------------------------------------------------*/

--- a/ball/game_draw.c
+++ b/ball/game_draw.c
@@ -144,17 +144,16 @@ static void game_draw_jumps(struct s_rend *rend,
 
 static void game_draw_tilt(const struct game_draw *gd, int d)
 {
+    static const float Y[3] = { 0.0f, 1.0f, 0.0f };
+
     const struct game_tilt *tilt = &gd->tilt;
     const float *ball_p = gd->vary.uv[0].p;
 
-    float q[4], axis[3], angle;
+    float axis[3], angle;
 
-    q[0] =  tilt->q[0];
-    q[1] = -tilt->q[1] * d;
-    q[2] =  tilt->q[2];
-    q[3] = -tilt->q[3] * d;
+    q_as_axisangle(tilt->q, axis, &angle);
 
-    q_as_axisangle(q, axis, &angle);
+    v_reflect(axis, axis, Y);
 
     /* Rotate the environment about the position of the ball. */
 

--- a/ball/game_server.c
+++ b/ball/game_server.c
@@ -281,23 +281,10 @@ static void game_cmd_jump(int e)
     game_proxy_enq(&cmd);
 }
 
-static void game_cmd_tiltangles(void)
+static void game_cmd_tilt(void)
 {
-    cmd.type = CMD_TILT_ANGLES;
-
-    cmd.tiltangles.x = tilt.rx;
-    cmd.tiltangles.z = tilt.rz;
-
-    game_proxy_enq(&cmd);
-}
-
-static void game_cmd_tiltaxes(void)
-{
-    cmd.type = CMD_TILT_AXES;
-
-    v_cpy(cmd.tiltaxes.x, tilt.x);
-    v_cpy(cmd.tiltaxes.z, tilt.z);
-
+    cmd.type = CMD_TILT;
+    q_cpy(cmd.tilt.q, tilt.q);
     game_proxy_enq(&cmd);
 }
 
@@ -768,10 +755,9 @@ static int game_step(const float g[3], float dt, int bt)
         tilt.rx += (input_get_x() - tilt.rx) * dt / MAX(dt, input_get_s());
         tilt.rz += (input_get_z() - tilt.rz) * dt / MAX(dt, input_get_s());
 
-        game_tilt_axes(&tilt, view.e);
+        game_tilt_calc(&tilt, view.e);
 
-        game_cmd_tiltaxes();
-        game_cmd_tiltangles();
+        game_cmd_tilt();
 
         grow_step(dt);
 

--- a/share/cmd.c
+++ b/share/cmd.c
@@ -367,6 +367,14 @@ DEFINE_CMD(CMD_MOVE_TIME, INDEX_BYTES + FLOAT_BYTES, {
 
 /*---------------------------------------------------------------------------*/
 
+DEFINE_CMD(CMD_TILT, ARRAY_BYTES(4), {
+    put_array(fp, cmd->tilt.q, 4);
+}, {
+    get_array(fp, cmd->tilt.q, 4);
+});
+
+/*---------------------------------------------------------------------------*/
+
 #define PUT_CASE(t) case t: cmd_put_ ## t(fp, cmd); break
 #define GET_CASE(t) case t: cmd_get_ ## t(fp, cmd); break
 
@@ -415,6 +423,7 @@ int cmd_put(fs_file fp, const union cmd *cmd)
         PUT_CASE(CMD_TILT_AXES);
         PUT_CASE(CMD_MOVE_PATH);
         PUT_CASE(CMD_MOVE_TIME);
+        PUT_CASE(CMD_TILT);
 
     case CMD_NONE:
     case CMD_MAX:
@@ -482,6 +491,7 @@ int cmd_get(fs_file fp, union cmd *cmd)
             GET_CASE(CMD_TILT_AXES);
             GET_CASE(CMD_MOVE_PATH);
             GET_CASE(CMD_MOVE_TIME);
+            GET_CASE(CMD_TILT);
 
         case CMD_NONE:
         case CMD_MAX:

--- a/share/cmd.h
+++ b/share/cmd.h
@@ -65,6 +65,7 @@ enum cmd_type
     CMD_TILT_AXES,
     CMD_MOVE_PATH,
     CMD_MOVE_TIME,
+    CMD_TILT,
 
     CMD_MAX
 };
@@ -289,6 +290,12 @@ struct cmd_move_time
     float t;
 };
 
+struct cmd_tilt
+{
+    CMD_HEADER;
+    float q[4];
+};
+
 union cmd
 {
     enum cmd_type type;
@@ -329,6 +336,7 @@ union cmd
     struct cmd_tilt_axes          tiltaxes;
     struct cmd_move_path          movepath;
     struct cmd_move_time          movetime;
+    struct cmd_tilt               tilt;
 };
 
 #undef CMD_HEADER

--- a/share/vec3.c
+++ b/share/vec3.c
@@ -53,6 +53,14 @@ void v_crs(float *u, const float *v, const float *w)
     u[2] = v[0] * w[1] - v[1] * w[0];
 }
 
+void v_reflect(float u[3], const float v[3], const float n[3])
+{
+    float w[3];
+
+    v_scl(w, n, 2.0f * v_dot(n, v));
+    v_sub(u, w, v);
+}
+
 /*---------------------------------------------------------------------------*/
 
 void m_cpy(float *M, const float *N)

--- a/share/vec3.h
+++ b/share/vec3.h
@@ -113,6 +113,7 @@
 
 void   v_nrm(float *, const float *);
 void   v_crs(float *, const float *, const float *);
+void   v_reflect(float u[3], const float v[3], const float n[3]);
 
 void   m_cpy(float *, const float *);
 void   m_xps(float *, const float *);


### PR DESCRIPTION
This replaces CMD_TILT_AXES/CMD_TILT_ANGLES combo (8 floats) with a CMD_TILT quaternion (4 floats).

It cuts down on replay size by about 11%, but not sure if gameplay remains unaffected. @fwp, what say you?

![cmd-tilt-stats](https://user-images.githubusercontent.com/179160/83339863-6b994b00-a2da-11ea-9a8f-565669d2f542.png)
