### PR TITLE
Add OARS metadata to appdata file

### DIFF
--- a/dist/neverball.appdata.xml
+++ b/dist/neverball.appdata.xml
@@ -28,4 +28,5 @@
     </screenshot>
   </screenshots>
   <url type="bugtracker">https://github.com/Neverball/neverball</url>
+  <content_rating type="oars-1.1" />
 </component>


### PR DESCRIPTION
[OARS metadata](https://hughsie.github.io/oars/) are required by many modern AppStream parsers.