### PR TITLE
Added some missing dependencies to documentation

### DIFF
--- a/doc/install.txt
+++ b/doc/install.txt
@@ -10,6 +10,8 @@
     libvorbis         http://xiph.org/vorbis/
     libpng            http://libpng.org/pub/png/libpng.html
     libjpeg           http://ijg.org/
+    gettext           https://www.gnu.org/software/gettext/
+    cURL              https://curl.se/
 
 
 * COMPILATION


### PR DESCRIPTION
When I compiled Neverball, I had error messages telling me I had missing stuff. I thought I could add those to the documentation and contribute them back.

I formatted them the way I thought was the most similar to what was already there; I left the branch on my repo open for modifications by maintainers, so feel free to edit it on my branch directly if you wish.