### PR TITLE
fix potential array out of bounds crash in image_load

### DIFF
--- a/share/base_image.c
+++ b/share/base_image.c
@@ -224,7 +224,7 @@ void *image_load(const char *filename, int *width,
                                        int *height,
                                        int *bytes)
 {
-    if (filename)
+    if (filename && strlen(filename) > 4)
     {
         const char *ext = filename + strlen(filename) - 4;
 


### PR DESCRIPTION
This function checks the filename extension, but sometimes empty strings are passed in, causing an out of bounds access in strcmp.