### PR TITLE
Added missing include in share/fetch_curl.h

### DIFF
--- a/share/fetch_curl.c
+++ b/share/fetch_curl.c
@@ -1,4 +1,5 @@
 #include "fetch.h"
+#include "common.h"
 #include "version.h"
 #include "list.h"
 #include "log.h"


### PR DESCRIPTION
Fixes #237

Without this include, `strdup` (which is `#define`d as a custom function, `dupe_string` in `share/common.h`) would not have a visible definition and would be assumed to return an `int` type, which is 32-bit, and will therefore truncate the address on 64-bit platforms.

This fix makes the declaration visible by including `share/common.h`, thus preventing truncation and the carrying of an incorrect address pointer value.