### PR TITLE
updated sets.txt to include iLevels & Penwielder

### DIFF
--- a/data/sets.txt
+++ b/data/sets.txt
@@ -5,4 +5,10 @@ set-mym.txt
 set-mym2.txt
 set-fwp.txt
 set-tones.txt
+set-iLevels.txt
+set-iLevels2.txt
+set-iLevels3.txt
+set-iLevels4.txt
+set-iLevels5.txt
+set-penscrap.txt
 set-misc.txt


### PR DESCRIPTION
Because all five Reshaun's iLevels sets, as well as Penwielder's Scrapbook, are now built-in downloadable levels, I decided to include them in the sets.txt file.