### PR TITLE
Change movements of collectible clocks

### DIFF
--- a/data/item/clock/clock15.map
+++ b/data/item/clock/clock15.map
@@ -6,25 +6,33 @@
 }
 {
 "classname" "path_corner"
+"targetname" "delay"
+"angles" "0 0 0"
+"target" "rot0"
+"speed" "0.5"
+"smooth" "0"
+}
+{
+"classname" "path_corner"
 "targetname" "rot0"
-"angle" "0"
+"angles" "0 0 0"
 "target" "rot120"
-"speed" "0.333"
+"speed" "0.167"
 "smooth" "0"
 }
 {
 "classname" "path_corner"
 "targetname" "rot120"
-"angle" "120"
+"angles" "0 0 120"
 "target" "rot240"
-"speed" "0.333"
+"speed" "0.167"
 "smooth" "0"
 }
 {
 "classname" "path_corner"
 "targetname" "rot240"
-"angle" "240"
-"target" "rot0"
-"speed" "0.333"
+"angles" "0 0 240"
+"target" "delay"
+"speed" "0.167"
 "smooth" "0"
 }

--- a/data/item/clock/clock30.map
+++ b/data/item/clock/clock30.map
@@ -6,25 +6,33 @@
 }
 {
 "classname" "path_corner"
+"targetname" "delay"
+"angles" "0 0 0"
+"target" "rot0"
+"speed" "0.5"
+"smooth" "0"
+}
+{
+"classname" "path_corner"
 "targetname" "rot0"
-"angle" "0"
+"angles" "0 0 0"
 "target" "rot120"
-"speed" "0.333"
+"speed" "0.167"
 "smooth" "0"
 }
 {
 "classname" "path_corner"
 "targetname" "rot120"
-"angle" "120"
+"angles" "0 0 120"
 "target" "rot240"
-"speed" "0.333"
+"speed" "0.167"
 "smooth" "0"
 }
 {
 "classname" "path_corner"
 "targetname" "rot240"
-"angle" "240"
-"target" "rot0"
-"speed" "0.333"
+"angles" "0 0 240"
+"target" "delay"
+"speed" "0.167"
 "smooth" "0"
 }

--- a/data/item/clock/clock5.map
+++ b/data/item/clock/clock5.map
@@ -6,25 +6,33 @@
 }
 {
 "classname" "path_corner"
+"targetname" "delay"
+"angles" "0 0 0"
+"target" "rot0"
+"speed" "0.5"
+"smooth" "0"
+}
+{
+"classname" "path_corner"
 "targetname" "rot0"
-"angle" "0"
+"angles" "0 0 0"
 "target" "rot120"
-"speed" "0.333"
+"speed" "0.167"
 "smooth" "0"
 }
 {
 "classname" "path_corner"
 "targetname" "rot120"
-"angle" "120"
+"angles" "0 0 120"
 "target" "rot240"
-"speed" "0.333"
+"speed" "0.167"
 "smooth" "0"
 }
 {
 "classname" "path_corner"
 "targetname" "rot240"
-"angle" "240"
-"target" "rot0"
-"speed" "0.333"
+"angles" "0 0 240"
+"target" "delay"
+"speed" "0.167"
 "smooth" "0"
 }


### PR DESCRIPTION
After seeing the discussion about distinct shapes for the clocks, I realised that there's another way to distinguish the clocks from the money coins besides distinct colors without having a unique shape. If they had a distinct movement, they can also be told apart from coins. This movement I proposed is a half-second delay with a half-second horizontal rotation ("roll" rotation about the x-axis instead of "yaw" rotation about the z-axis like the money coins do). However, using the coin movement's speed about the x-axis poses a problem: the skin that shows the clock's denomination appears upside-down, which can confuse players (players can mistake a clock that gives five more seconds as fifty more seconds if upside-down). To alleviate that, I made the rotation twice as fast & put a 0.5 second delay at the point where the denomination is right-side up to allow players to read the denomination.