### PR TITLE
Change movement of collectible clocks

### DIFF
--- a/data/item/clock/clock15.map
+++ b/data/item/clock/clock15.map
@@ -24,7 +24,31 @@
 "classname" "path_corner"
 "targetname" "rot240"
 "angle" "240"
-"target" "rot0"
+"target" "flip0"
 "speed" "0.333"
+"smooth" "0"
+}
+{
+"classname" "path_corner"
+"targetname" "flip0"
+"angle" "0"
+"target" "flip120"
+"speed" "0.167"
+"smooth" "0"
+}
+{
+"classname" "path_corner"
+"targetname" "flip120"
+"angles" "0 0 120"
+"target" "flip240"
+"speed" "0.167"
+"smooth" "0"
+}
+{
+"classname" "path_corner"
+"targetname" "flip240"
+"angles" "0 0 240"
+"target" "rot0"
+"speed" "0.167"
 "smooth" "0"
 }

--- a/data/item/clock/clock30.map
+++ b/data/item/clock/clock30.map
@@ -24,7 +24,31 @@
 "classname" "path_corner"
 "targetname" "rot240"
 "angle" "240"
-"target" "rot0"
+"target" "flip0"
 "speed" "0.333"
+"smooth" "0"
+}
+{
+"classname" "path_corner"
+"targetname" "flip0"
+"angle" "0"
+"target" "flip120"
+"speed" "0.167"
+"smooth" "0"
+}
+{
+"classname" "path_corner"
+"targetname" "flip120"
+"angles" "0 0 120"
+"target" "flip240"
+"speed" "0.167"
+"smooth" "0"
+}
+{
+"classname" "path_corner"
+"targetname" "flip240"
+"angles" "0 0 240"
+"target" "rot0"
+"speed" "0.167"
 "smooth" "0"
 }

--- a/data/item/clock/clock5.map
+++ b/data/item/clock/clock5.map
@@ -24,7 +24,31 @@
 "classname" "path_corner"
 "targetname" "rot240"
 "angle" "240"
-"target" "rot0"
+"target" "flip0"
 "speed" "0.333"
+"smooth" "0"
+}
+{
+"classname" "path_corner"
+"targetname" "flip0"
+"angle" "0"
+"target" "flip120"
+"speed" "0.167"
+"smooth" "0"
+}
+{
+"classname" "path_corner"
+"targetname" "flip120"
+"angles" "0 0 120"
+"target" "flip240"
+"speed" "0.167"
+"smooth" "0"
+}
+{
+"classname" "path_corner"
+"targetname" "flip240"
+"angles" "0 0 240"
+"target" "rot0"
+"speed" "0.167"
 "smooth" "0"
 }


### PR DESCRIPTION
https://user-images.githubusercontent.com/99624782/169611102-5bcf78a7-a1c8-4960-a767-076619442a80.mp4

This PR changes the movements of the collectible clocks to be distinct from the movement of the money coins so that they can be distinguished easier. As the video shows, the clocks make a full revolution about the vertical axis the same speed as the coins, then make revolution (two flips) at half the speed about the horizontal axis. The reason that the clocks make two flips instead of one is because one flip can make the clock skin appear upside down.