### PR TITLE
change movement of collectible clocks

### DIFF
--- a/data/item/clock/clock15.map
+++ b/data/item/clock/clock15.map
@@ -24,7 +24,71 @@
 "classname" "path_corner"
 "targetname" "rot240"
 "angle" "240"
-"target" "rot0"
+"target" "rot360"
 "speed" "0.333"
+"smooth" "0"
+}
+{
+"classname" "path_corner"
+"targetname" "rot360"
+"angle" "0"
+"target" "rot480"
+"speed" "0.333"
+"smooth" "0"
+}
+{
+"classname" "path_corner"
+"targetname" "rot480"
+"angle" "120"
+"target" "rot600"
+"speed" "0.333"
+"smooth" "0"
+}
+{
+"classname" "path_corner"
+"targetname" "rot600"
+"angle" "240"
+"target" "delay0"
+"speed" "0.333"
+"smooth" "0"
+}
+{
+"classname" "path_corner"
+"targetname" "delay0"
+"angle" "0"
+"target" "flip0"
+"speed" "0.25"
+"smooth" "0"
+}
+{
+"classname" "path_corner"
+"targetname" "flip0"
+"angle" "0"
+"target" "flip120"
+"speed" "0.167"
+"smooth" "0"
+}
+{
+"classname" "path_corner"
+"targetname" "flip120"
+"angles" "0 0 120"
+"target" "flip240"
+"speed" "0.167"
+"smooth" "0"
+}
+{
+"classname" "path_corner"
+"targetname" "flip240"
+"angles" "0 0 240"
+"target" "delay1"
+"speed" "0.167"
+"smooth" "0"
+}
+{
+"classname" "path_corner"
+"targetname" "delay1"
+"angle" "0"
+"target" "rot0"
+"speed" "0.25"
 "smooth" "0"
 }

--- a/data/item/clock/clock30.map
+++ b/data/item/clock/clock30.map
@@ -24,7 +24,71 @@
 "classname" "path_corner"
 "targetname" "rot240"
 "angle" "240"
-"target" "rot0"
+"target" "rot360"
 "speed" "0.333"
+"smooth" "0"
+}
+{
+"classname" "path_corner"
+"targetname" "rot360"
+"angle" "0"
+"target" "rot480"
+"speed" "0.333"
+"smooth" "0"
+}
+{
+"classname" "path_corner"
+"targetname" "rot480"
+"angle" "120"
+"target" "rot600"
+"speed" "0.333"
+"smooth" "0"
+}
+{
+"classname" "path_corner"
+"targetname" "rot600"
+"angle" "240"
+"target" "delay0"
+"speed" "0.333"
+"smooth" "0"
+}
+{
+"classname" "path_corner"
+"targetname" "delay0"
+"angle" "0"
+"target" "flip0"
+"speed" "0.25"
+"smooth" "0"
+}
+{
+"classname" "path_corner"
+"targetname" "flip0"
+"angle" "0"
+"target" "flip120"
+"speed" "0.167"
+"smooth" "0"
+}
+{
+"classname" "path_corner"
+"targetname" "flip120"
+"angles" "0 0 120"
+"target" "flip240"
+"speed" "0.167"
+"smooth" "0"
+}
+{
+"classname" "path_corner"
+"targetname" "flip240"
+"angles" "0 0 240"
+"target" "delay1"
+"speed" "0.167"
+"smooth" "0"
+}
+{
+"classname" "path_corner"
+"targetname" "delay1"
+"angle" "0"
+"target" "rot0"
+"speed" "0.25"
 "smooth" "0"
 }

--- a/data/item/clock/clock5.map
+++ b/data/item/clock/clock5.map
@@ -24,7 +24,71 @@
 "classname" "path_corner"
 "targetname" "rot240"
 "angle" "240"
-"target" "rot0"
+"target" "rot360"
 "speed" "0.333"
+"smooth" "0"
+}
+{
+"classname" "path_corner"
+"targetname" "rot360"
+"angle" "0"
+"target" "rot480"
+"speed" "0.333"
+"smooth" "0"
+}
+{
+"classname" "path_corner"
+"targetname" "rot480"
+"angle" "120"
+"target" "rot600"
+"speed" "0.333"
+"smooth" "0"
+}
+{
+"classname" "path_corner"
+"targetname" "rot600"
+"angle" "240"
+"target" "delay0"
+"speed" "0.333"
+"smooth" "0"
+}
+{
+"classname" "path_corner"
+"targetname" "delay0"
+"angle" "0"
+"target" "flip0"
+"speed" "0.25"
+"smooth" "0"
+}
+{
+"classname" "path_corner"
+"targetname" "flip0"
+"angle" "0"
+"target" "flip120"
+"speed" "0.167"
+"smooth" "0"
+}
+{
+"classname" "path_corner"
+"targetname" "flip120"
+"angles" "0 0 120"
+"target" "flip240"
+"speed" "0.167"
+"smooth" "0"
+}
+{
+"classname" "path_corner"
+"targetname" "flip240"
+"angles" "0 0 240"
+"target" "delay1"
+"speed" "0.167"
+"smooth" "0"
+}
+{
+"classname" "path_corner"
+"targetname" "delay1"
+"angle" "0"
+"target" "rot0"
+"speed" "0.25"
 "smooth" "0"
 }


### PR DESCRIPTION
https://user-images.githubusercontent.com/99624782/169712210-b48c9c34-81dc-4b17-8821-8dc42d2b81a0.mp4

This PR changes the movements of the collectible clocks, so that they can be easily told apart from money coins. The movements in the video consist of the following:

1) Two full revolutions (showing the denomination four times).
2) A quarter-second delay.
3) A quick flip.
4) Another quarter-second delay.