### PR TITLE
Replace Neverforum link with Discord link

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ Release highlights can be found in [doc/release-notes.md](doc/release-notes.md).
 
 * [Website](http://neverball.org/)
 * [Development](http://github.com/Neverball)
-* [Neverforum](http://neverforum.com/)
+* [Discord](https://discord.gg/bmBfHKZaQR)
 * [#neverball on chat.freenode.net](http://webchat.freenode.net/)
 
 ## Translation


### PR DESCRIPTION
As the Neverforum's currently broken, I decided to remove the link & replace it with a Discord invite.