### PR TITLE
Replace SDL_mutexP/V with SDL_(Un)LockMutex

### DIFF
--- a/share/tilt_loop.c
+++ b/share/tilt_loop.c
@@ -154,15 +154,15 @@ static int tilt_func(void *data)
     }
 
 
-    SDL_mutexP(mutex);
+    SDL_LockMutex(mutex);
     state.status = running;
-    SDL_mutexV(mutex);
+    SDL_UnlockMutex(mutex);
 
     while (mutex && running)
     {
-        SDL_mutexP(mutex);
+        SDL_LockMutex(mutex);
         running = state.status;
-        SDL_mutexV(mutex);
+        SDL_UnlockMutex(mutex);
 
         rc = freespace_read(deviceId, buffer, FREESPACE_MAX_INPUT_MESSAGE_SIZE, 100, &length);
         if (rc != FREESPACE_SUCCESS) {
@@ -184,7 +184,7 @@ static int tilt_func(void *data)
             /* This function does euler decomposition for rotate the object type (ZYX, aerospace) */
             q_euler(eulerAngles, quat);
 
-            SDL_mutexP(mutex);
+            SDL_LockMutex(mutex);
             {
                 /* Since the game expects "rotate the world type", conjugate by negating all angles & convert to degrees
                  * Z is yaw
@@ -201,7 +201,7 @@ static int tilt_func(void *data)
                 set_button(&state.U, userFrame.deltaWheel > 0);
                 set_button(&state.D, userFrame.deltaWheel < 0);
             }
-            SDL_mutexV(mutex);
+            SDL_UnlockMutex(mutex);
         }
 
     }
@@ -228,10 +228,10 @@ void tilt_free(void)
     {
         /* Get/set the status of the tilt sensor thread. */
 
-        SDL_mutexP(mutex);
+        SDL_LockMutex(mutex);
         b = state.status;
         state.status = 0;
-        SDL_mutexV(mutex);
+        SDL_UnlockMutex(mutex);
 
         /* Kill the thread and destroy the mutex. */
 
@@ -251,7 +251,7 @@ int tilt_get_button(int *b, int *s)
 
     if (mutex)
     {
-        SDL_mutexP(mutex);
+        SDL_LockMutex(mutex);
         {
             if      ((ch = get_button(&state.A)))
             {
@@ -279,7 +279,7 @@ int tilt_get_button(int *b, int *s)
                 *s = (ch == BUTTON_DN);
             }
         }
-        SDL_mutexV(mutex);
+        SDL_UnlockMutex(mutex);
     }
     return ch;
 }
@@ -290,9 +290,9 @@ float tilt_get_x(void)
 
     if (mutex)
     {
-        SDL_mutexP(mutex);
+        SDL_LockMutex(mutex);
         x = state.x;
-        SDL_mutexV(mutex);
+        SDL_UnlockMutex(mutex);
     }
 
     return x;
@@ -304,9 +304,9 @@ float tilt_get_z(void)
 
     if (mutex)
     {
-        SDL_mutexP(mutex);
+        SDL_LockMutex(mutex);
         z = state.z;
-        SDL_mutexV(mutex);
+        SDL_UnlockMutex(mutex);
     }
 
     return z;
@@ -318,9 +318,9 @@ int tilt_stat(void)
 
     if (mutex)
     {
-        SDL_mutexP(mutex);
+        SDL_LockMutex(mutex);
         b = state.status;
-        SDL_mutexV(mutex);
+        SDL_UnlockMutex(mutex);
     }
     return b;
 }

--- a/share/tilt_wii.c
+++ b/share/tilt_wii.c
@@ -120,16 +120,16 @@ static int tilt_func(void *data)
             wiimote.mode.bits = WIIMOTE_MODE_ACC;
             wiimote.led.one   = 1;
 
-            SDL_mutexP(mutex);
+            SDL_LockMutex(mutex);
             state.status = running;
-            SDL_mutexV(mutex);
+            SDL_UnlockMutex(mutex);
 
             while (mutex && running && wiimote_is_open(&wiimote))
             {
                 if (wiimote_update(&wiimote) < 0)
                     break;
 
-                SDL_mutexP(mutex);
+                SDL_LockMutex(mutex);
                 {
                     running = state.status;
 
@@ -154,7 +154,7 @@ static int tilt_func(void *data)
                                    wiimote.tilt.x) / FILTER;
                     }
                 }
-                SDL_mutexV(mutex);
+                SDL_UnlockMutex(mutex);
             }
 
             wiimote_disconnect(&wiimote);
@@ -177,9 +177,9 @@ void tilt_free(void)
     {
         /* Get/set the status of the tilt sensor thread. */
 
-        SDL_mutexP(mutex);
+        SDL_LockMutex(mutex);
         state.status = 0;
-        SDL_mutexV(mutex);
+        SDL_UnlockMutex(mutex);
 
         /* Wait for the thread to terminate and destroy the mutex. */
 
@@ -196,7 +196,7 @@ int tilt_get_button(int *b, int *s)
 
     if (mutex)
     {
-        SDL_mutexP(mutex);
+        SDL_LockMutex(mutex);
         {
             if      ((ch = get_button(&state.A)))
             {
@@ -244,7 +244,7 @@ int tilt_get_button(int *b, int *s)
                 *s = (ch == BUTTON_DN);
             }
         }
-        SDL_mutexV(mutex);
+        SDL_UnlockMutex(mutex);
     }
     return ch;
 }
@@ -255,9 +255,9 @@ float tilt_get_x(void)
 
     if (mutex)
     {
-        SDL_mutexP(mutex);
+        SDL_LockMutex(mutex);
         x = state.x;
-        SDL_mutexV(mutex);
+        SDL_UnlockMutex(mutex);
     }
 
     return x;
@@ -269,9 +269,9 @@ float tilt_get_z(void)
 
     if (mutex)
     {
-        SDL_mutexP(mutex);
+        SDL_LockMutex(mutex);
         z = state.z;
-        SDL_mutexV(mutex);
+        SDL_UnlockMutex(mutex);
     }
 
     return z;
@@ -283,9 +283,9 @@ int tilt_stat(void)
 
     if (mutex)
     {
-        SDL_mutexP(mutex);
+        SDL_LockMutex(mutex);
         b = state.status;
-        SDL_mutexV(mutex);
+        SDL_UnlockMutex(mutex);
     }
     return b;
 }

--- a/share/tilt_wiiuse.c
+++ b/share/tilt_wiiuse.c
@@ -83,15 +83,15 @@ static int tilt_thread(void *data)
     wiiuse_set_smooth_alpha(wm, smooth_alpha);
     wiiuse_set_leds(wm, WIIMOTE_LED_1);
 
-    SDL_mutexP(mutex);
+    SDL_LockMutex(mutex);
     current_state.status = 1;
-    SDL_mutexV(mutex);
+    SDL_UnlockMutex(mutex);
 
     while (mutex && current_state.status && WIIMOTE_IS_CONNECTED(wm)) {
         if (wiiuse_poll(wiimotes, NB_WIIMOTES)) {
             switch (wm->event) {
                 case WIIUSE_EVENT:
-                    SDL_mutexP(mutex);
+                    SDL_LockMutex(mutex);
                     /* start on 4 because the 4 first buttons are for the nunchuk */
                     for (i = 4; i < NB_WIIMOTE_BUTTONS; i++) {
                         current_state.buttons[i] = IS_PRESSED(wm, wiiUseButtons[i][0]);
@@ -117,7 +117,7 @@ static int tilt_thread(void *data)
                             current_state.z = wm->orient.roll * roll_sensitivity;
                         }
                     }
-                    SDL_mutexV(mutex);
+                    SDL_UnlockMutex(mutex);
                     break;
                 default:
                     break;
@@ -183,9 +183,9 @@ void tilt_free(void)
     {
         /* Get/set the status of the tilt sensor thread. */
 
-        SDL_mutexP(mutex);
+        SDL_LockMutex(mutex);
         current_state.status = 0;
-        SDL_mutexV(mutex);
+        SDL_UnlockMutex(mutex);
 
         /* Wait for the thread to terminate and destroy the mutex. */
 
@@ -201,7 +201,7 @@ int tilt_get_button(int *b, int *s)
     int i = NB_WIIMOTE_BUTTONS;
 
     if (mutex) {
-        SDL_mutexP(mutex);
+        SDL_LockMutex(mutex);
         if (current_state.status) {
             for (i = 0; i < NB_WIIMOTE_BUTTONS; i++) {
                 if (current_state.buttons[i] != polled_state.buttons[i]) {
@@ -212,7 +212,7 @@ int tilt_get_button(int *b, int *s)
                 }
             }
         }
-        SDL_mutexV(mutex);
+        SDL_UnlockMutex(mutex);
     }
 
     return i < NB_WIIMOTE_BUTTONS;
@@ -224,9 +224,9 @@ float tilt_get_x(void)
 
     if (mutex)
     {
-        SDL_mutexP(mutex);
+        SDL_LockMutex(mutex);
         x = current_state.x;
-        SDL_mutexV(mutex);
+        SDL_UnlockMutex(mutex);
     }
 
     return x;
@@ -238,9 +238,9 @@ float tilt_get_z(void)
 
     if (mutex)
     {
-        SDL_mutexP(mutex);
+        SDL_LockMutex(mutex);
         z = current_state.z;
-        SDL_mutexV(mutex);
+        SDL_UnlockMutex(mutex);
     }
 
     return z;
@@ -252,9 +252,9 @@ int tilt_stat(void)
 
     if (mutex)
     {
-        SDL_mutexP(mutex);
+        SDL_LockMutex(mutex);
         b = current_state.status;
-        SDL_mutexV(mutex);
+        SDL_UnlockMutex(mutex);
     }
     return b;
 }


### PR DESCRIPTION
SDL's wiki mentions that [SDL_mutexV](https://wiki.libsdl.org/SDL2/SDL_mutexV) and [SDL_mutexP](https://wiki.libsdl.org/SDL2/SDL_mutexP) have since been replaced.