### PR TITLE
New orthonormalization macros for best suggestion (math/basis)

### DIFF
--- a/ball/game_common.c
+++ b/ball/game_common.c
@@ -199,10 +199,7 @@ void game_view_fly(struct game_view *view, const struct s_vary *vary, float k)
     /* Orthonormalize the view basis. */
 
     v_sub(view->e[2], view->p, view->c);
-    v_crs(view->e[0], view->e[1], view->e[2]);
-    v_crs(view->e[2], view->e[0], view->e[1]);
-    v_nrm(view->e[0], view->e[0]);
-    v_nrm(view->e[2], view->e[2]);
+    e_orthonrm_xz(view->e);
 }
 
 /*---------------------------------------------------------------------------*/

--- a/ball/game_server.c
+++ b/ball/game_server.c
@@ -630,10 +630,7 @@ static void game_update_view(float dt)
 
     /* Orthonormalize the new view reference frame. */
 
-    v_crs(view.e[0], view.e[1], view.e[2]);
-    v_crs(view.e[2], view.e[0], view.e[1]);
-    v_nrm(view.e[0], view.e[0]);
-    v_nrm(view.e[2], view.e[2]);
+    e_orthonrm_xz(multiview1.e);
 
     /* Compute the new view position. */
 

--- a/ball/game_server.c
+++ b/ball/game_server.c
@@ -630,7 +630,7 @@ static void game_update_view(float dt)
 
     /* Orthonormalize the new view reference frame. */
 
-    e_orthonrm_xz(multiview1.e);
+    e_orthonrm_xz(view.e);
 
     /* Compute the new view position. */
 

--- a/putt/game.c
+++ b/putt/game.c
@@ -398,10 +398,7 @@ void game_update_view(float dt)
 
     /* Orthonormalize the basis of the view in its new position. */
 
-    v_crs(view_e[0], view_e[1], view_e[2]);
-    v_crs(view_e[2], view_e[0], view_e[1]);
-    v_nrm(view_e[0], view_e[0]);
-    v_nrm(view_e[2], view_e[2]);
+    e_orthonrm_xz(view_e);
 
     /* The current view (dy, dz) approaches the ideal (view_dy, view_dz). */
 
@@ -663,10 +660,7 @@ void game_set_fly(float k)
     /* Orthonormalize the view basis. */
 
     v_sub(view_e[2], view_p, view_c);
-    v_crs(view_e[0], view_e[1], view_e[2]);
-    v_crs(view_e[2], view_e[0], view_e[1]);
-    v_nrm(view_e[0], view_e[0]);
-    v_nrm(view_e[2], view_e[2]);
+    e_orthonrm_xz(view_e);
 
     view_a = V_DEG(fatan2f(view_e[2][0], view_e[2][2]));
 }

--- a/share/solid_all.c
+++ b/share/solid_all.c
@@ -179,13 +179,7 @@ void sol_rotate(float e[3][3], const float w[3], float dt)
 
         /* Re-orthonormalize the basis. */
 
-        v_crs(e[2], f[0], f[1]);
-        v_crs(e[1], f[2], f[0]);
-        v_crs(e[0], f[1], f[2]);
-
-        v_nrm(e[0], e[0]);
-        v_nrm(e[1], e[1]);
-        v_nrm(e[2], e[2]);
+        e_orthonrm_hard(e, f);
     }
 }
 

--- a/share/vec3.h
+++ b/share/vec3.h
@@ -102,6 +102,22 @@
     v_nrm((e)[2], (e)[2]);         \
 } while (0)
 
+#define e_orthonrm_xz(e) do {      \
+    v_crs((e)[0], (e)[1], (e)[2]); \
+    v_crs((e)[2], (e)[0], (e)[1]); \
+    v_nrm((e)[0], (e)[0]);         \
+    v_nrm((e)[2], (e)[2]);         \
+} while (0)
+
+#define e_orthonrm_hard(e, f) do { \
+    v_crs((e)[2], (f)[0], (f)[1]); \
+    v_crs((e)[1], (f)[2], (f)[0]); \
+    v_crs((e)[0], (f)[1], (f)[2]); \
+    v_nrm((e)[0], (e)[0]);         \
+    v_nrm((e)[1], (e)[1]);         \
+    v_nrm((e)[2], (e)[2]);         \
+} while (0)
+
 #define e_lerp(c, d, e, a) do {        \
     v_lerp((c)[0], (d)[0], (e)[0], a); \
     v_lerp((c)[1], (d)[1], (e)[1], a); \


### PR DESCRIPTION
If you orthonormalize the basis for matrix but your duplicated workaround is greater than your math-macros, you'll have to compress it by implement the new macro function.

The Auto-Resolve features on this pulls makes this easy, by suggesting the best course of action to settle your new function.

If you want to resolve your new macros manually, you can do so.

**Compress re-orthonormalization**

```
// Add your macros into vec3.h below

#define e_orthonrm_hard(e, f) do { \
    v_crs((e)[2], (f)[0], (f)[1]); \
    v_crs((e)[1], (f)[2], (f)[0]); \
    v_crs((e)[0], (f)[1], (f)[2]); \
    v_nrm((e)[0], (e)[0]);         \
    v_nrm((e)[1], (e)[1]);         \
    v_nrm((e)[2], (e)[2]);         \
} while (0)
```

Compress the re-orthonormalization as macro function. They will be replaced from six to one line: *solid_all.c:sol_rotate*.

**Compress orthonormalization (View)**

```
// Add your macros into vec3.h below

#define e_orthonrm_xz(e) do {      \
    v_crs((e)[0], (e)[1], (e)[2]); \
    v_crs((e)[2], (e)[0], (e)[1]); \
    v_nrm((e)[0], (e)[0]);         \
    v_nrm((e)[2], (e)[2]);         \
} while (0)
```

Compress the view orthonormalization as macro function. Source file must be synced evenly across the source directory: *ball/game_server.c*, *ball/game_common.c*, *putt/game.c*
