### PR TITLE
Add option to skip holes in Neverputt

### DIFF
--- a/putt/main.c
+++ b/putt/main.c
@@ -43,6 +43,8 @@
 const char TITLE[] = "Neverputt " VERSION;
 const char ICON[] = "icon/neverputt.png";
 
+static int skip_draw = 0;
+
 /*---------------------------------------------------------------------------*/
 
 static void shot(void)
@@ -293,6 +295,13 @@ static void opt_parse(int argc, char **argv)
 
 /*---------------------------------------------------------------------------*/
 
+void set_skipping(int s)
+{
+    skip_draw = s;
+}
+
+/*---------------------------------------------------------------------------*/
+
 int main(int argc, char *argv[])
 {
     int camera = 0;
@@ -374,12 +383,18 @@ int main(int argc, char *argv[])
                 {
                     st_timer((t1 - t0) / 1000.f);
                     hmd_step();
-                    st_paint(0.001f * t1);
-                    video_swap();
+
+                    if (!skip_draw)
+                    {
+                        st_paint(0.001f * t1);
+                        video_swap();
+                    }
+                    else
+                        t1 -= 100;
 
                     t0 = t1;
 
-                    if (config_get_d(CONFIG_NICE))
+                    if (config_get_d(CONFIG_NICE) && !skip_draw)
                         SDL_Delay(1);
                 }
 

--- a/putt/st_all.c
+++ b/putt/st_all.c
@@ -702,6 +702,11 @@ static int pause_buttn(int b, int d)
 
 static int shared_keybd(int c, int d)
 {
+    if (curr_state() == &st_roll)
+    {
+        set_skipping(1);
+    }
+
     if (d)
     {
         if (c == KEY_EXIT)
@@ -1045,9 +1050,9 @@ static void roll_timer(int id, float dt)
 
     switch (game_step(g, dt))
     {
-    case GAME_STOP: goto_state(&st_stop); break;
-    case GAME_GOAL: goto_state(&st_goal); break;
-    case GAME_FALL: goto_state(&st_fall); break;
+    case GAME_STOP: goto_state(&st_stop); set_skipping(0); break;
+    case GAME_GOAL: goto_state(&st_goal); set_skipping(0); break;
+    case GAME_FALL: goto_state(&st_fall); set_skipping(0); break;
     }
 }
 


### PR DESCRIPTION
I did this for my personal comfort, I thought I'd share in case it can be useful to the community. This is how I've designed it for myself, but I'm open to adapt it on request.

-------------------

This adds an option to skip the hole in the pause menu, which avoids having to manually spend attempts to skip a hole.

Skipping sets the score of all players to the maximum amount (including for players who already finished) and shows the scoreboard.

![image](https://user-images.githubusercontent.com/66701383/217098394-42847b6c-bf6f-4073-8232-e7a102d74e1e.png)
![image](https://user-images.githubusercontent.com/66701383/217098434-167a46a7-9f10-4703-a4f3-11e041a6e400.png)
