### PR TITLE
Add option to skip holes in Neverputt

### DIFF
--- a/putt/hole.c
+++ b/putt/hole.c
@@ -368,6 +368,20 @@ void hole_stop(void)
     }
 }
 
+void hole_skip(void)
+{
+    int maxscore = (score_v[hole][0] > 12 - 3) ? score_v[hole][0] + 3 : 12;
+    int i;
+
+    for (i = 1; i <= party; i++)
+    {
+        score_v[hole][i] = maxscore;
+        stat_v[i] = 1;
+    }
+
+    done = party;
+}
+
 void hole_fall(void)
 {
     audio_play(AUD_PENALTY, 1.0f);

--- a/putt/hole.h
+++ b/putt/hole.h
@@ -31,6 +31,7 @@ int  hole_next(void);
 int  hole_move(void);
 void hole_goal(void);
 void hole_stop(void);
+void hole_skip(void);
 void hole_fall(void);
 
 void hole_song(void);

--- a/putt/st_all.c
+++ b/putt/st_all.c
@@ -596,6 +596,7 @@ static struct state *st_quit;
 
 #define PAUSE_CONTINUE 1
 #define PAUSE_QUIT     2
+#define PAUSE_SKIP     3
 
 int goto_pause(struct state *s)
 {
@@ -618,6 +619,10 @@ static int pause_action(int i)
     case PAUSE_CONTINUE:
         return goto_state(st_continue ? st_continue : &st_title);
 
+    case PAUSE_SKIP:
+        hole_skip();
+        return goto_state(&st_score);
+
     case PAUSE_QUIT:
         return goto_state(st_quit);
     }
@@ -638,7 +643,8 @@ static int pause_enter(struct state *st, struct state *prev)
         if ((jd = gui_harray(id)))
         {
             gui_state(jd, _("Quit"), GUI_SML, PAUSE_QUIT, 0);
-            gui_start(jd, _("Continue"), GUI_SML, PAUSE_CONTINUE, 1);
+            gui_state(jd, _("Skip"), GUI_SML, PAUSE_SKIP, 1);
+            gui_start(jd, _("Continue"), GUI_SML, PAUSE_CONTINUE, 2);
         }
 
         gui_pulse(td, 1.2f);


### PR DESCRIPTION
I did this for my personal comfort, I thought I'd share in case it can be useful to the community. This is how I've designed it for myself, but I'm open to adapt it on request.

-------------------

This adds an option to skip the hole in the pause menu, which avoids having to manually spend attempts to skip a hole.

Skipping sets the score of all players to the maximum amount (including for players who already finished) and shows the scoreboard.

![image](https://user-images.githubusercontent.com/66701383/217098394-42847b6c-bf6f-4073-8232-e7a102d74e1e.png)
![image](https://user-images.githubusercontent.com/66701383/217098434-167a46a7-9f10-4703-a4f3-11e041a6e400.png)
