### PR TITLE
OpenGL Extensions: Fixed crashes

### DIFF
--- a/share/glext.c
+++ b/share/glext.c
@@ -148,6 +148,8 @@ int glext_init(void)
         SDL_GL_GFPA(glClientActiveTexture_, "glClientActiveTextureARB");
         SDL_GL_GFPA(glActiveTexture_,       "glActiveTextureARB");
     }
+    else
+        return 0;
 
     if (glext_assert("ARB_vertex_buffer_object"))
     {
@@ -158,12 +160,16 @@ int glext_init(void)
         SDL_GL_GFPA(glDeleteBuffers_,       "glDeleteBuffersARB");
         SDL_GL_GFPA(glIsBuffer_,            "glIsBufferARB");
     }
+    else
+        return 0;
 
     if (glext_assert("ARB_point_parameters"))
     {
-        SDL_GL_GFPA(glPointParameterf_,    "glPointParameterfARB");
-        SDL_GL_GFPA(glPointParameterfv_,   "glPointParameterfvARB");
+        SDL_GL_GFPA(glPointParameterf_, "glPointParameterfARB");
+        SDL_GL_GFPA(glPointParameterfv_, "glPointParameterfvARB");
     }
+    else
+        return 0;
 
     if (glext_check("ARB_shader_objects"))
     {
@@ -201,7 +207,11 @@ int glext_init(void)
     }
 
     if (glext_check("GREMEDY_string_marker"))
+    {
         SDL_GL_GFPA(glStringMarkerGREMEDY_, "glStringMarkerGREMEDY");
+
+        gli.string_marker = 1;
+    }
 
 #endif
 

--- a/share/glext.h
+++ b/share/glext.h
@@ -305,6 +305,7 @@ struct gl_info
     unsigned int texture_filter_anisotropic : 1;
     unsigned int shader_objects             : 1;
     unsigned int framebuffer_object         : 1;
+    unsigned int string_marker              : 1;
 };
 
 extern struct gl_info gli;

--- a/share/solid_draw.c
+++ b/share/solid_draw.c
@@ -813,7 +813,9 @@ static void check_mtrl(const char *name, GLenum pname, GLuint curr)
     if (real != curr)
     {
         sprintf(buff, "%s mismatch (0x%08X -> 0x%08X)", name, real, curr);
-        glStringMarker_(buff);
+
+        if (gli.string_marker)
+            glStringMarker_(buff);
     }
 }
 


### PR DESCRIPTION
Fixed some crashes where string markers and all GL extensions is missing after init