### PR TITLE
Neverputt cheats

### DIFF
--- a/putt/hole.c
+++ b/putt/hole.c
@@ -388,6 +388,17 @@ void hole_fall(void)
     }
 }
 
+void hole_retry(void)
+{
+    game_set_pos(ball_p[player], ball_e[player]);
+}
+
+void hole_restart(void)
+{
+    memset(&score_v[hole][1], 0, sizeof (int) * party);
+    hole_goto(hole, party);
+}
+
 /*---------------------------------------------------------------------------*/
 
 void hole_song(void)

--- a/putt/hole.h
+++ b/putt/hole.h
@@ -32,6 +32,8 @@ int  hole_move(void);
 void hole_goal(void);
 void hole_stop(void);
 void hole_fall(void);
+void hole_retry(void);
+void hole_restart(void);
 
 void hole_song(void);
 

--- a/putt/st_all.c
+++ b/putt/st_all.c
@@ -30,6 +30,8 @@
 
 /*---------------------------------------------------------------------------*/
 
+static int play_id = 0;
+
 static char *number(int i)
 {
     static char str[MAXSTR];
@@ -226,9 +228,19 @@ static int title_enter(struct state *st, struct state *prev)
 
             if ((kd = gui_varray(jd)))
             {
-                gui_start(kd, gt_prefix("menu^Play"),    GUI_MED, TITLE_PLAY, 1);
-                gui_state(kd, gt_prefix("menu^Options"), GUI_MED, TITLE_CONF, 0);
-                gui_state(kd, gt_prefix("menu^Exit"),    GUI_MED, TITLE_EXIT, 0);
+                if (config_cheat())
+                    play_id = gui_start(kd, gt_prefix("menu^Cheat"),
+                                        GUI_MED, TITLE_PLAY, 1);
+                else
+                    play_id = gui_start(kd, gt_prefix("menu^Play"),
+                                        GUI_MED, TITLE_PLAY, 1);
+
+                gui_state(  kd, gt_prefix("menu^Options"),  GUI_MED, TITLE_CONF, 0);
+                gui_state(  kd, gt_prefix("menu^Exit"),     GUI_MED, TITLE_EXIT, 0);
+
+                /* Hilight the start button. */
+
+                gui_set_hilite(play_id, 1);
             }
 
             gui_filler(jd);
@@ -594,8 +606,11 @@ static int paused = 0;
 static struct state *st_continue;
 static struct state *st_quit;
 
-#define PAUSE_CONTINUE 1
-#define PAUSE_QUIT     2
+enum {
+    PAUSE_CONTINUE = 1,
+    PAUSE_QUIT,
+    PAUSE_RESTART
+};
 
 int goto_pause(struct state *s)
 {
@@ -618,6 +633,10 @@ static int pause_action(int i)
     case PAUSE_CONTINUE:
         return goto_state(st_continue ? st_continue : &st_title);
 
+    case PAUSE_RESTART:
+        hole_restart();
+        return goto_state(&st_next);
+
     case PAUSE_QUIT:
         return goto_state(st_quit);
     }
@@ -638,6 +657,8 @@ static int pause_enter(struct state *st, struct state *prev)
         if ((jd = gui_harray(id)))
         {
             gui_state(jd, _("Quit"), GUI_SML, PAUSE_QUIT, 0);
+            if (config_cheat())
+                gui_state(jd, _("Restart"), GUI_SML, PAUSE_RESTART, 0);
             gui_start(jd, _("Continue"), GUI_SML, PAUSE_CONTINUE, 1);
         }
 
@@ -1051,6 +1072,23 @@ static void roll_timer(int id, float dt)
     }
 }
 
+static int roll_keybd(int c, int d)
+{
+    shared_keybd(c, d);
+
+    if (d)
+    {
+        /* Cheats */
+
+        if (config_cheat()) {
+            if (config_tst_d(CONFIG_KEY_RESTART, c)) {
+                return goto_state(&st_retry);
+            }
+        }
+    }
+    return 1;
+}
+
 static int roll_buttn(int b, int d)
 {
     if (d)
@@ -1282,6 +1320,80 @@ static int fall_buttn(int b, int d)
 
 /*---------------------------------------------------------------------------*/
 
+static int retry_enter(struct state *st, struct state *prev)
+{
+    int id;
+
+    if ((id = gui_label(0, _("Retry"), GUI_MED, gui_blk, gui_red)))
+        gui_layout(id, 0, 0);
+
+    if (paused)
+        paused = 0;
+    else
+    {
+        hole_retry();
+    }
+
+    hud_init();
+
+    return id;
+}
+
+static void retry_leave(struct state *st, struct state *next, int id)
+{
+    gui_delete(id);
+    hud_free();
+}
+
+static void retry_paint(int id, float t)
+{
+    game_draw(0, t);
+    gui_paint(id);
+    hud_paint();
+}
+
+static void retry_timer(int id, float dt)
+{
+    if (time_state() > 1)
+    {
+        if (hole_next())
+            goto_state(&st_next);
+        else
+            goto_state(&st_score);
+    }
+}
+
+static int retry_click(int b, int d)
+{
+    if (b == SDL_BUTTON_LEFT && d == 1)
+    {
+        if (hole_next())
+            goto_state(&st_next);
+        else
+            goto_state(&st_score);
+    }
+    return 1;
+}
+
+static int retry_buttn(int b, int d)
+{
+    if (d)
+    {
+        if (config_tst_d(CONFIG_JOYSTICK_BUTTON_A, b))
+        {
+            if (hole_next())
+                goto_state(&st_next);
+            else
+                goto_state(&st_score);
+        }
+        if (config_tst_d(CONFIG_JOYSTICK_BUTTON_B, b))
+            return goto_pause(&st_over);
+    }
+    return 1;
+}
+
+/*---------------------------------------------------------------------------*/
+
 static int score_enter(struct state *st, struct state *prev)
 {
     audio_music_fade_out(2.f);
@@ -1480,7 +1592,7 @@ struct state st_roll = {
     NULL,
     NULL,
     NULL,
-    shared_keybd,
+    roll_keybd,
     roll_buttn
 };
 
@@ -1521,6 +1633,19 @@ struct state st_fall = {
     fall_click,
     shared_keybd,
     fall_buttn
+};
+
+struct state st_retry = {
+    retry_enter,
+    retry_leave,
+    retry_paint,
+    retry_timer,
+    NULL,
+    NULL,
+    NULL,
+    retry_click,
+    shared_keybd,
+    retry_buttn
 };
 
 struct state st_score = {

--- a/putt/st_all.h
+++ b/putt/st_all.h
@@ -14,6 +14,7 @@ extern struct state st_roll;
 extern struct state st_goal;
 extern struct state st_stop;
 extern struct state st_fall;
+extern struct state st_retry;
 extern struct state st_score;
 extern struct state st_over;
 extern struct state st_pause;


### PR DESCRIPTION
# Changes

## With `cheat 0`:

* Changed the color of the "Play" button like in Neverball

## With `cheat 1`:

* "Play" button changes label to "Cheat"

* `CONFIG_KEY_RESTART` is used to retry a shot. It works like a fall, but without penalty

* Pause menu has "Restart" button, which resets hole to initial state for all players

# Suggestions

After making this, I noticed two other similar prs (#99 and #326) and thought the behavior could be changed with cheats disabled: `CONFIG_KEY_RESTART` could force the fall state with penalty and the "Restart" button could be changed to "Skip".

By the way, should the number keys in `next_keybd` function only work with cheats?