### PR TITLE
Fix bugs related to timed switches

### DIFF
--- a/ball/game_server.c
+++ b/ball/game_server.c
@@ -725,7 +725,7 @@ static int game_update_state(int bt)
 
     /* Test for a switch. */
 
-    if (sol_swch_test(&vary, game_proxy_enq, 0) == SWCH_INSIDE)
+    if (sol_swch_test(&vary, game_proxy_enq, 0) == SWCH_ACTUATE)
         audio_play(AUD_SWITCH, 1.f);
 
     /* Test for a jump. */

--- a/putt/game.c
+++ b/putt/game.c
@@ -437,7 +437,7 @@ static int game_update_state(float dt)
 
     /* Test for a switch. */
 
-    if (sol_swch_test(fp, NULL, ball) == SWCH_INSIDE)
+    if (sol_swch_test(fp, NULL, ball) == SWCH_ACTUATE)
         audio_play(AUD_SWITCH, 1.f);
 
     /* Test for a jump. */

--- a/share/solid_all.c
+++ b/share/solid_all.c
@@ -526,7 +526,7 @@ int sol_swch_test(struct s_vary *vary, cmd_fn cmd_func, int ui)
     const float *ball_p = vary->uv[ui].p;
     const float  ball_r = vary->uv[ui].r;
 
-    int xi, rc = SWCH_OUTSIDE;
+    int xi, rc = SWCH_NONE;
 
     for (xi = 0; xi < vary->xc; xi++)
     {
@@ -584,7 +584,7 @@ int sol_swch_test(struct s_vary *vary, cmd_fn cmd_func, int ui)
                         /* If visible, play the sound. */
 
                         if (!xp->base->i)
-                            rc = SWCH_INSIDE;
+                            rc = SWCH_ACTUATE;
                     }
 
                 }
@@ -631,7 +631,7 @@ int sol_swch_test(struct s_vary *vary, cmd_fn cmd_func, int ui)
                     /* If visible, play the sound. */
 
                     if (!xp->base->i)
-                        rc = SWCH_INSIDE;
+                        rc = SWCH_ACTUATE;
                 }
 
             }

--- a/share/solid_all.c
+++ b/share/solid_all.c
@@ -315,12 +315,12 @@ void sol_swch_step(struct s_vary *vary, cmd_fn cmd_func, float dt, int ms)
     {
         struct v_swch *xp = vary->xv + xi;
 
-        if (xp->tm < xp->base->tm)
+        if (xp->tm > 0)
         {
-            xp->t += dt;
-            xp->tm += ms;
+            xp->t -= dt;
+            xp->tm -= ms;
 
-            if (xp->tm >= xp->base->tm)
+            if (xp->tm <= 0)
             {
                 sol_path_loop(vary, cmd_func, xp->base->pi, xp->base->f);
 
@@ -542,16 +542,13 @@ int sol_swch_test(struct s_vary *vary, cmd_fn cmd_func, int ui)
                 {
                     /* The ball enters. */
 
-                    if (xp->base->tm == 0)
-                    {
-                        xp->e = 1;
+                    xp->e = 1;
 
-                        if (cmd_func)
-                        {
-                            union cmd cmd = { CMD_SWCH_ENTER };
-                            cmd.swchenter.xi = xi;
-                            cmd_func(&cmd);
-                        }
+                    if (cmd_func)
+                    {
+                        union cmd cmd = { CMD_SWCH_ENTER };
+                        cmd.swchenter.xi = xi;
+                        cmd_func(&cmd);
                     }
 
                     /* Toggle the state, update the path. */
@@ -569,10 +566,10 @@ int sol_swch_test(struct s_vary *vary, cmd_fn cmd_func, int ui)
 
                     /* It toggled to non-default state, start the timer. */
 
-                    if (xp->f != xp->base->f)
+                    if (xp->f != xp->base->f && xp->base->tm != 0)
                     {
-                        xp->t = 0.0f;
-                        xp->tm = 0;
+                        xp->t = xp->base->t;
+                        xp->tm = xp->base->tm;
                     }
 
                     /* If visible, set the result. */

--- a/share/solid_all.c
+++ b/share/solid_all.c
@@ -322,7 +322,8 @@ void sol_swch_step(struct s_vary *vary, cmd_fn cmd_func, float dt, int ms)
 
             if (xp->tm <= 0)
             {
-                /* Only toggle the paths if no other timer is active. */
+                /* Only toggle the paths if no other timer 
+                 * controlling the same paths is active. */
                 
                 int others_active = 0;
                 int xj;
@@ -553,17 +554,14 @@ int sol_swch_test(struct s_vary *vary, cmd_fn cmd_func, int ui)
                 ball_p[1] > xp->base->p[1] &&
                 ball_p[1] < xp->base->p[1] + SWCH_HEIGHT / 2)
             {
-
                 /* The ball is completely inside the switch. */
 
                 if (d <= 0.0)
                 {
-
                     /* The ball just now entered the switch. */
 
                     if (!xp->e)
                     {
-
                         xp->e = 1;
                         if (cmd_func)
                         {
@@ -645,7 +643,6 @@ int sol_swch_test(struct s_vary *vary, cmd_fn cmd_func, int ui)
             else if (xp->e)
             {
                 xp->e = 0;
-
                 if (cmd_func)
                 {
                     union cmd cmd = { CMD_SWCH_EXIT };

--- a/share/solid_all.c
+++ b/share/solid_all.c
@@ -543,10 +543,10 @@ int sol_swch_test(struct s_vary *vary, cmd_fn cmd_func, int ui)
         d = v_len(r) + ball_r - xp->base->r;
 
         /*
-            * The  "touch"  distance, which  must  be cleared  before
-            * being able to trigger a switch, is the ball's diameter.
-            * (This is different from teleporters.)
-            */
+        * The  "touch"  distance, which  must  be cleared  before
+        * being able to trigger a switch, is the ball's diameter.
+        * (This is different from teleporters.)
+        */
 
         if (d <= ball_r * 2 &&
             ball_p[1] > xp->base->p[1] &&
@@ -590,7 +590,7 @@ int sol_swch_test(struct s_vary *vary, cmd_fn cmd_func, int ui)
                 }
 
                 /* If it's a timed switch, and the timer is off, 
-                    * turn it on and start the timer. */
+                * turn it on and start the timer. */
 
                 if (xp->base->tm != 0 && xp->f == xp->base->f)
                 {
@@ -604,7 +604,7 @@ int sol_swch_test(struct s_vary *vary, cmd_fn cmd_func, int ui)
                     sol_path_loop(vary, cmd_func, xp->base->pi, xp->f);
 
                     /* Look at all switches pointing to the same path.
-                        * See which one has the most time left. */
+                    * See which one has the most time left. */
 
                     float t_max = 0.0f;
                     float tm_max = 0;
@@ -622,8 +622,8 @@ int sol_swch_test(struct s_vary *vary, cmd_fn cmd_func, int ui)
                     }
 
                     /* Set the timer. If another timer pointing to the
-                        * same path is still active, make this timer
-                        * run a little longer by adding t_max, tm_max. */
+                    * same path is still active, make this timer
+                    * run a little longer by adding t_max, tm_max. */
 
                     xp->t = xp->base->t + t_max;
                     xp->tm = xp->base->tm + tm_max;
@@ -635,6 +635,9 @@ int sol_swch_test(struct s_vary *vary, cmd_fn cmd_func, int ui)
                 }
 
             }
+
+            /* The ball is no longer inside the timed switch. */
+
             else if (xp->e && xp->base->tm != 0)
             {
                 xp->e = 0;
@@ -647,7 +650,7 @@ int sol_swch_test(struct s_vary *vary, cmd_fn cmd_func, int ui)
             }
         }
 
-        /* The ball is no longer touching the switch. */
+        /* The ball is no longer touching the toggle switch. */
 
         else if (xp->e && xp->base->tm == 0)
         {

--- a/share/solid_all.h
+++ b/share/solid_all.h
@@ -39,9 +39,8 @@ enum
 
 enum
 {
-    SWCH_OUTSIDE = 0,
-    SWCH_INSIDE,
-    SWCH_TOUCH
+    SWCH_NONE = 0,
+    SWCH_ACTUATE
 };
 
 int            sol_item_test(struct s_vary *, float *p, float item_r);

--- a/share/solid_sim_sol.c
+++ b/share/solid_sim_sol.c
@@ -682,11 +682,11 @@ static float sol_path_time(struct s_vary *vary, float dt)
     {
         struct v_swch *xp = vary->xv + xi;
 
-        if (xp->tm >= xp->base->tm)
+        if (xp->tm == 0)
             continue;
 
-        if (xp->tm + ms_peek(&vary->ms_accum, dt) > xp->base->tm)
-            dt = MS_TO_TIME(xp->base->tm - xp->tm);
+        if (xp->tm - ms_peek(&vary->ms_accum, dt) <= 0)
+            dt = MS_TO_TIME(xp->tm);
     }
 
     return dt;

--- a/share/solid_vary.c
+++ b/share/solid_vary.c
@@ -113,8 +113,8 @@ int sol_load_vary(struct s_vary *fp, struct s_base *base)
             struct b_swch *xq = fp->base->xv + i;
 
             xp->base = xq;
-            xp->t    = xq->t;
-            xp->tm   = xq->tm;
+            xp->t    = 0;
+            xp->tm   = 0;
             xp->f    = xq->f;
         }
     }


### PR DESCRIPTION
This pull request addresses some bugs related to timed switches. Changes to behavior include:

1. Fix an ancient bug where enter/exit events don't work for timed switches.

As a consequence of this bugfix, when a ball enters a timed switch, the switch's beam is highlighted. This is similar to how toggle switch and teleporter beams highlight when the ball is inside them.

I made it so the timed switch's beam will only highlight if the ball is completely inside the switch. That way, the highlight serves as a visual indicator for if the ball's in the right position to re-activate the timed switch.

In practice, this is purely a visual change.

2. Address a corner case involving multiple timed switches controlling the same path.

The best way to see what this bugfix is about is to play Medium level 18. Activate the first switch, and then quickly activate the second switch before the platform stops moving. You will see the platform stop moving as soon as the first switch expires, but the second switch remains green.

There are two potential ways to fix this. One method is to lock all switches when one switch is activated and only unlock them after the timer expires. Another method is to allow the player to unlock the other switch. The total time the path is activated is equal to the sum of the individual switch's timers. 

I think the latter option is preferable because it is similar to existing behavior and it is more fun than having to wait around for the previous switch to expire.

Here are the specifics of how this is implemented. Timed switches now count down to 0. When a player activates a timed switch, the game first checks if any other timed switches controlling the same path are active. It finds the maximum time remaining out of those switches (usually 0, but sometimes not) and adds it to this switch's base timer. When a timed switch expires, it first checks whether any other switches are active. It will only toggle the path if no other timer controlling the same path is active.

Here's an example. Say the player activates a 3-second switch. Then, only 2 seconds later, the player activates another 3-second switch controlling the same moving platform. The second switch will then be active for a total of 4 seconds instead of 3. The platform moves a total of 6 seconds.

This change affects levels where multiple timed switches target the same path and the player can travel between the switches faster than the switch expires.