### PR TITLE
Fix wiiuse linker flags in Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -171,7 +171,7 @@ ifeq ($(ENABLE_TILT),wii)
 	TILT_LIBS := -lcwiimote -lbluetooth
 else
 ifeq ($(ENABLE_TILT),wiiuse)
-	TILT_LIBS := -lwiiuse
+	TILT_LIBS := -lwiiuse -lbluetooth
 else
 ifeq ($(ENABLE_TILT),loop)
 	TILT_LIBS := -lusb-1.0 -lfreespace


### PR DESCRIPTION
The needed "-lbluetooth" linker flag was missing when enabling the "wiiuse" tilt feature, adding it fixes linker errors when compiling (tested in Ubuntu 22.04 LTS).