### PR TITLE
tones swapped scores: Fix ordering of scores for hotwheels.map.

### DIFF
--- a/data/map-tones/hotwheels.map
+++ b/data/map-tones/hotwheels.map
@@ -9,8 +9,8 @@
 "shot" "shot-tones/hotwheels.jpg"
 "time" "3000"
 "goal" "40"
-"time_hs" "2650 2800"
-"goal_hs" "1800 1850"
+"time_hs" "1800 1850"
+"goal_hs" "2650 2800"
 "coin_hs" "58 50"
 "message" "Learn the course and stick to the rails!"
 // brush 0


### PR DESCRIPTION
While attempting an all-hard challenge, I noticed that in the Tones level set, 2 levels seem to have 2 high scores that are swapped, rather than what seems to have been intended or better design.  Normally the fast unlock hard has more time than the best times hard, although technically this doesn't need to be the case.  In 2 levels, it seems they may have accidentally been swapped.

I didn't create this level set, but I think this would be a reasonable maintenance.

The first of two PRs addresses the easier of the two level changes: level 15 (hotwheels.map) has both its fast unlock values less than either best times value.  Presumably these were meant to be swapped.

The second PR flips swaps just the hard value for best times and fast unlock, since the medium value is ordered as expected.  It applies to level 11 (leaps.map).  (I still managed to beat all hards on this level as it currently stands, but it seemed uncharacteristically difficult for this level set.)  This PR only swaps hard, not both hard and medium like the first.

In case the original author wanted to provide input or do something other than swap, as he adjusted scores once before in 2014 (3fa0b2cfd0fee1ece232aa21325d87d7e50fd203), I'm pinging @tonesfrommars.

@MightyBurger also mentioned he might want to add a texture fix in this level set to go along with these changes.
