### PR TITLE
Make Addons menu transparent

### DIFF
--- a/ball/main.c
+++ b/ball/main.c
@@ -57,6 +57,7 @@
 #include "st_common.h"
 #include "st_start.h"
 #include "st_package.h"
+#include "st_shared.h"
 
 const char TITLE[] = "Neverball";
 const char ICON[] = "icon/neverball.png";
@@ -937,6 +938,8 @@ static int main_init(int argc, char *argv[])
     package_init();
 
     package_set_installed_action(handle_installed_action);
+
+    package_set_paint_action(shared_paint);
 
     /* Enable joystick events. */
 

--- a/ball/main.c
+++ b/ball/main.c
@@ -494,6 +494,8 @@ static int process_link(const char *link)
             else if ((index = package_search(set_file)) >= 0)
             {
                 log_printf("Found package with the given reference.\n");
+                load_title_background();
+                game_kill_fade();
                 goto_package(index, &st_title);
                 processed = 1;
             }

--- a/share/st_package.c
+++ b/share/st_package.c
@@ -63,6 +63,7 @@ struct download_info
 };
 
 static int (*installed_action)(int pi);
+static void (*paint_action)(int id, float st);
 
 /*---------------------------------------------------------------------------*/
 
@@ -521,8 +522,6 @@ static int package_enter(struct state *st, struct state *prev)
 {
     common_init(package_action);
 
-    back_init("back/gui.png");
-
     if (do_init)
     {
         package_back = prev;
@@ -576,13 +575,8 @@ static void package_leave(struct state *st, struct state *next, int id)
 
 void package_paint(int id, float st)
 {
-    video_push_persp((float) config_get_d(CONFIG_VIEW_FOV), 0.1f, FAR_DIST);
-    {
-        back_draw_easy();
-    }
-    video_pop_matrix();
-
-    gui_paint(id);
+    if (paint_action)
+        paint_action(id, st);
 }
 
 static void package_point(int id, int x, int y, int dx, int dy)
@@ -625,6 +619,10 @@ void goto_package(int package_id, struct state *back_state)
 void package_set_installed_action(int (*installed_action_fn)(int pi))
 {
     installed_action = installed_action_fn;
+}
+
+void package_set_paint_action(void (*paint_action_fn)(int id, float st)) {
+    paint_action = paint_action_fn;
 }
 
 /*---------------------------------------------------------------------------*/

--- a/share/st_package.h
+++ b/share/st_package.h
@@ -7,5 +7,6 @@ extern struct state st_package;
 
 void goto_package(int package_id, struct state *back_state);
 void package_set_installed_action(int (*installed_action_fn)(int pi));
+void package_set_paint_action(void (*paint_action_fn)(int id, float st));
 
 #endif


### PR DESCRIPTION
# What?

This PR makes the Addons screen transparent.

Current:
![image](https://github.com/user-attachments/assets/5c688ca0-30b6-4388-b0cf-21491b8a7026)

After changes in this PR:
![image](https://github.com/user-attachments/assets/303be84c-6299-4ce9-9bfd-d38c74934c4e)

# Why?

This is actually an indirect bugfix.

I noticed a bug with the Addons related to a recent change in commit c279f08. When you launch the game, select Addons, choose a level set you already have installed, and click "Start", it opens the level selection screen but with an incorrect background gradient:

![image](https://github.com/user-attachments/assets/f4dd6310-3e9d-4a46-ab06-bde2ff2f3bb0)

I believe the bug is caused by the call `back_init("back/gui.png")` in the function `package_enter`. The background gradient gets set to `back/gui.png`, but it is not restored to the previous gradient when transitioning to the level selection screen.

This could be solved directly while keeping the blue background in the Addons screen, but I wanted to propose this change as an alternative solution. The aesthetic change fixes the bug since clicking the "Addons" button no longer changes the background gradient.

I think it's up to your personal preference, @parasti, whether you like this aesthetic change or would rather keep the blue background in the Addons screen.

# How?
This PR makes the function `package_paint()` call `shared_paint()` instead of `back_draw_easy()`. This is the same behavior as other states like the "set" state.

Because `package.c` belongs in `share/`, I couldn't use `shared_paint()` directly. Instead, I made a new function `package_set_paint_action()` called by `main_init()` inside `main.c`. It uses the exact same pattern as the `package_set_installed_action()` function added in c279f08. (I probably could've chosen a better name.)

`package_enter()` no longer calls `back_init("back/gui.png")`.

I added calls to `load_title_background(); game_kill_fade();` to correctly load the title background when launching the game with the `--link` option.

Those are all the changes.
