### PR TITLE
Lojban translation: correct translation of ‘Cancel’.

### DIFF
--- a/po/jbo.po
+++ b/po/jbo.po
@@ -449,7 +449,7 @@ msgstr "je'e"
 
 #: ball/st_name.c:116 ball/st_save.c:115 ball/st_save.c:224
 msgid "Cancel"
-msgstr "porfa'o"
+msgstr "ra'erprogau"
 
 #: ball/st_over.c:43
 msgid "GAME OVER"


### PR DESCRIPTION
This just corrects a small mistake I caught right after submission.

Thanks, and enjoy having a Lojban language option!