### PR TITLE
Fix transition on double click

### DIFF
--- a/share/state.c
+++ b/share/state.c
@@ -128,6 +128,8 @@ static int goto_state_intent(struct state *st, int intent)
 {
     struct state *prev = state;
 
+    transition_age();
+
     if (state && state->leave)
         state->leave(state, st, state->gui_id, intent);
 

--- a/share/transition.c
+++ b/share/transition.c
@@ -34,19 +34,26 @@
  * That's what all this is for.
  */
 
+#define TRANSITION_MAX (16)
+
 /* Widget IDs with exit animations. */
-static int widget_ids[16];
+static int widget_ids[TRANSITION_MAX];
+
+/* How many state transitions have they lived through? */
+static int widget_ages[TRANSITION_MAX];
 
 /*---------------------------------------------------------------------------*/
 
 void transition_init(void)
 {
     memset(widget_ids, 0, sizeof (widget_ids));
+    memset(widget_ages, 0, sizeof (widget_ages));
 }
 
 void transition_quit(void)
 {
     memset(widget_ids, 0, sizeof (widget_ids));
+    memset(widget_ages, 0, sizeof (widget_ages));
 }
 
 void transition_add(int id)
@@ -57,6 +64,7 @@ void transition_add(int id)
         if (!widget_ids[i])
         {
             widget_ids[i] = id;
+            widget_ages[i] = 0;
             break;
         }
 
@@ -76,7 +84,22 @@ void transition_remove(int id)
         if (widget_ids[i] == id)
         {
             widget_ids[i] = 0;
+            widget_ages[i] = 0;
             break;
+        }
+}
+
+void transition_age(void)
+{
+    int i;
+
+    for (i = 0; i < ARRAYSIZE(widget_ids); ++i)
+        if (widget_ids[i])
+        {
+            if (++widget_ages[i] >= 1)
+            {
+                gui_remove(widget_ids[i]);
+            }
         }
 }
 

--- a/share/transition.h
+++ b/share/transition.h
@@ -24,6 +24,8 @@ void transition_quit(void);
 void transition_add(int id);
 void transition_remove(int id);
 
+void transition_age(void);
+
 void transition_timer(float dt);
 void transition_paint(void);
 


### PR DESCRIPTION
There is a bug where if you double click on the next set of replays shown, Neverball transitions into a bugged page with no replays and with the arrow button moved:

<img width="1920" height="1080" alt="favyke&#39;u-kunti" src="https://github.com/user-attachments/assets/e98d7a61-7cd7-4ee8-8e05-8e297618885e" />

This fixes this bug.