### PR TITLE
Build for Windows (x64 + ARM) in GitHub CI 

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,92 @@
+---
+name: Build
+on:
+  push:
+    branches:
+      - master
+  pull_request:
+    branches:
+      - master
+  workflow_dispatch:
+
+permissions: {}
+
+jobs:
+  windows:
+    name: Windows MSYS2
+    runs-on: ${{ matrix.arch == 'arm64' && 'windows-11-arm' || 'windows-2025' }}
+    strategy:
+      fail-fast: false
+      matrix:
+        arch: [x64, arm64]
+    permissions: 
+      contents: read
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v7
+        with:
+          persist-credentials: false
+      
+      - name: Setup MSYS2
+        uses: msys2/setup-msys2@v2
+        with:
+          update: true
+          msystem: ${{ matrix.arch == 'arm64' && 'CLANGARM64' || 'CLANG64' }}
+          install: >
+            base-devel
+            mingw-w64-clang-${{ matrix.arch == 'arm64' && 'aarch64' || 'x86_64' }}-toolchain
+            mingw-w64-clang-${{ matrix.arch == 'arm64' && 'aarch64' || 'x86_64' }}-pkgconf
+            mingw-w64-clang-${{ matrix.arch == 'arm64' && 'aarch64' || 'x86_64' }}-gettext
+            mingw-w64-clang-${{ matrix.arch == 'arm64' && 'aarch64' || 'x86_64' }}-SDL2
+            mingw-w64-clang-${{ matrix.arch == 'arm64' && 'aarch64' || 'x86_64' }}-SDL2_ttf
+            mingw-w64-clang-${{ matrix.arch == 'arm64' && 'aarch64' || 'x86_64' }}-curl
+            mingw-w64-clang-${{ matrix.arch == 'arm64' && 'aarch64' || 'x86_64' }}-libjpeg-turbo
+            mingw-w64-clang-${{ matrix.arch == 'arm64' && 'aarch64' || 'x86_64' }}-libpng
+            mingw-w64-clang-${{ matrix.arch == 'arm64' && 'aarch64' || 'x86_64' }}-libvorbis
+      
+      - name: Build Neverball
+        shell: msys2 {0}
+        run: |
+          make CC=clang -j"$(nproc 2>/dev/null || echo 1)"
+      
+      - name: Run binaries check
+        shell: msys2 {0}
+        run: |
+          file neverball.exe neverputt.exe mapc.exe
+          ./neverball.exe --version
+
+      - name: Create standalone tarball
+        shell: msys2 {0}
+        run: |
+          set -euo pipefail
+          bundle="neverball-${{ github.sha }}-windows-${{ matrix.arch }}"
+          rm -rf "$bundle"
+          mkdir -p "$bundle"
+
+          cp -a neverball.exe neverputt.exe mapc.exe "$bundle/"
+          cp -a data locale "$bundle/"
+          cp -a README.md LICENSE.md "$bundle/" || true
+
+          # Resolve MinGW/Clang prefix dynamically (clang64 / clangarm64)
+          mingw_prefix="$(cygpath -u "$MINGW_PREFIX")"
+
+          # Collect DLL dependencies
+          dlls=$(
+            (ldd neverball.exe; ldd neverputt.exe; ldd mapc.exe) |
+            awk -v p="$mingw_prefix/bin/" '/=>/ {print $3} { if (index($1, p) == 1) print $1 }' |
+            grep -Ei "^$mingw_prefix/bin/.*\.dll$" |
+            sort -u
+          )
+
+          for dll in $dlls; do
+            cp -a "$dll" "$bundle/"
+          done
+
+          tar -czf "$bundle.tar.gz" "$bundle"
+
+      - name: Upload standalone tarball
+        uses: actions/upload-artifact@v7
+        with:
+          name: neverball-windows-${{ matrix.arch }}
+          path: neverball-${{ github.sha }}-windows-${{ matrix.arch }}.tar.gz
+          archive: true

--- a/Makefile
+++ b/Makefile
@@ -494,7 +494,7 @@ WINDRES ?= windres
 	sh scripts/translate-desktop.sh < $< > $@
 
 %.ico.o: dist/ico/%.ico
-	echo "1 ICON \"$<\"" | $(WINDRES) -o $@
+	echo "1 ICON \"$<\"" | $(WINDRES) -o $@ -
 
 #------------------------------------------------------------------------------
 


### PR DESCRIPTION
Subset of https://github.com/Neverball/neverball/pull/422, needed for #452

Builds the game for Windows on the `CLANG64` and `CLANGARM64` [msys2 environments](https://github.com/msys2/setup-msys2?tab=readme-ov-file#msystem) (Windows 10+).

Those environments use the newer `UCRT` C runtime instead of the older `MSVCRT` runtime (unavailable to build for ARM).

Upload resulting builds as workflow artifacts.